### PR TITLE
feat(config): add a new config value to block sympathy in boss arenas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - you can combine a bloody needle and a poppet to create a bound poppet
 - you can now use the ritual of sympathy to cast spells on the target of a bound poppet
 - a new configuration has been added to block sympathetic magic in boss arenas
+- a new configuration has been added to prevent sympathetic magic from targeting bosses
 
 ### Changed
 - players now hold the vinteum needle in a more appropriate manner for stabbing people

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - you can now craft a poppet from wool and animus dust; they're cute l'il guys
 - you can combine a bloody needle and a poppet to create a bound poppet
 - you can now use the ritual of sympathy to cast spells on the target of a bound poppet
+- a new configuration has been added to block sympathetic magic in boss arenas
 
 ### Changed
 - players now hold the vinteum needle in a more appropriate manner for stabbing people

--- a/src/main/java/org/sosly/witchcraft/Config.java
+++ b/src/main/java/org/sosly/witchcraft/Config.java
@@ -16,12 +16,18 @@ public class Config
             .comment("Should sympathetic magic affect players when they are near bosses?")
             .define("bossesBlockSympathy", true);
 
+    private static final ForgeConfigSpec.BooleanValue BOSSES_IMMUNE_TO_SYMPATHY = BUILDER
+            .comment("Should bosses be immune to sympathetic magic?")
+            .define("bossesImmuneToSympathy", true);
+
     static final ForgeConfigSpec SPEC = BUILDER.build();
 
     public static boolean bossesBlockSympathy;
+    public static boolean bossesImmuneToSympathy;
 
     @SubscribeEvent
     static void onLoad(final ModConfigEvent event) {
         bossesBlockSympathy = BOSSES_BLOCK_SYMPATHY.get();
+        bossesImmuneToSympathy = BOSSES_IMMUNE_TO_SYMPATHY.get();
     }
 }

--- a/src/main/java/org/sosly/witchcraft/Config.java
+++ b/src/main/java/org/sosly/witchcraft/Config.java
@@ -1,16 +1,9 @@
 package org.sosly.witchcraft;
 
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Item;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.config.ModConfigEvent;
-import net.minecraftforge.registries.ForgeRegistries;
-
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 // An example config class. This is not required, but it's a good idea to have one to keep your config organized.
 // Demonstrates how to use Forge's config APIs
@@ -19,45 +12,16 @@ public class Config
 {
     private static final ForgeConfigSpec.Builder BUILDER = new ForgeConfigSpec.Builder();
 
-    private static final ForgeConfigSpec.BooleanValue LOG_DIRT_BLOCK = BUILDER
-            .comment("Whether to log the dirt block on common setup")
-            .define("logDirtBlock", true);
-
-    private static final ForgeConfigSpec.IntValue MAGIC_NUMBER = BUILDER
-            .comment("A magic number")
-            .defineInRange("magicNumber", 42, 0, Integer.MAX_VALUE);
-
-    public static final ForgeConfigSpec.ConfigValue<String> MAGIC_NUMBER_INTRODUCTION = BUILDER
-            .comment("What you want the introduction message to be for the magic number")
-            .define("magicNumberIntroduction", "The magic number is... ");
-
-    // a list of strings that are treated as resource locations for items
-    private static final ForgeConfigSpec.ConfigValue<List<? extends String>> ITEM_STRINGS = BUILDER
-            .comment("A list of items to log on common setup.")
-            .defineListAllowEmpty("items", List.of("minecraft:iron_ingot"), Config::validateItemName);
+    private static final ForgeConfigSpec.BooleanValue BOSSES_BLOCK_SYMPATHY = BUILDER
+            .comment("Should sympathetic magic affect players when they are near bosses?")
+            .define("bossesBlockSympathy", true);
 
     static final ForgeConfigSpec SPEC = BUILDER.build();
 
-    public static boolean logDirtBlock;
-    public static int magicNumber;
-    public static String magicNumberIntroduction;
-    public static Set<Item> items;
-
-    private static boolean validateItemName(final Object obj)
-    {
-        return obj instanceof final String itemName && ForgeRegistries.ITEMS.containsKey(new ResourceLocation(itemName));
-    }
+    public static boolean bossesBlockSympathy;
 
     @SubscribeEvent
-    static void onLoad(final ModConfigEvent event)
-    {
-        logDirtBlock = LOG_DIRT_BLOCK.get();
-        magicNumber = MAGIC_NUMBER.get();
-        magicNumberIntroduction = MAGIC_NUMBER_INTRODUCTION.get();
-
-        // convert the list of strings into a set of items
-        items = ITEM_STRINGS.get().stream()
-                .map(itemName -> ForgeRegistries.ITEMS.getValue(new ResourceLocation(itemName)))
-                .collect(Collectors.toSet());
+    static void onLoad(final ModConfigEvent event) {
+        bossesBlockSympathy = BOSSES_BLOCK_SYMPATHY.get();
     }
 }

--- a/src/main/java/org/sosly/witchcraft/events/items/VinteumNeedle.java
+++ b/src/main/java/org/sosly/witchcraft/events/items/VinteumNeedle.java
@@ -1,43 +1,20 @@
 package org.sosly.witchcraft.events.items;
 
 import com.mna.items.ItemInit;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.sounds.SoundEvents;
-import net.minecraft.sounds.SoundSource;
-import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.BucketItem;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.ClipContext;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.CraftingTableBlock;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.HitResult;
-import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.RegisterColorHandlersEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
-import net.minecraftforge.event.entity.player.PlayerEvent;
-import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.registries.ForgeRegistries;
+import org.sosly.witchcraft.Config;
 import org.sosly.witchcraft.Witchcraft;
-import org.sosly.witchcraft.blocks.BlockRegistry;
 import org.sosly.witchcraft.items.ItemRegistry;
-
-import java.util.UUID;
+import org.sosly.witchcraft.utils.SympathyHelper;
 
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class VinteumNeedle {
@@ -55,6 +32,10 @@ public class VinteumNeedle {
 
         Entity target = event.getTarget();
         if (!(target instanceof Player || target instanceof Mob)) {
+            return;
+        }
+
+        if (Config.bossesImmuneToSympathy && SympathyHelper.isBoss(target)) {
             return;
         }
 

--- a/src/main/java/org/sosly/witchcraft/rituals/effects/SympathyRitual.java
+++ b/src/main/java/org/sosly/witchcraft/rituals/effects/SympathyRitual.java
@@ -3,14 +3,20 @@ package org.sosly.witchcraft.rituals.effects;
 import com.mna.api.capabilities.IPlayerProgression;
 import com.mna.api.rituals.IRitualContext;
 import com.mna.api.rituals.RitualEffect;
+import com.mna.api.spells.ComponentApplicationResult;
 import com.mna.api.spells.ICanContainSpell;
+import com.mna.api.spells.base.IModifiedSpellPart;
 import com.mna.api.spells.base.ISpellDefinition;
+import com.mna.api.spells.parts.Shape;
+import com.mna.api.spells.parts.SpellEffect;
 import com.mna.api.spells.targeting.SpellContext;
 import com.mna.api.spells.targeting.SpellSource;
 import com.mna.api.spells.targeting.SpellTarget;
+import com.mna.api.tools.MATags;
 import com.mna.capabilities.playerdata.progression.PlayerProgressionProvider;
 import com.mna.items.filters.SpellItemFilter;
 import com.mna.spells.SpellsInit;
+import com.mna.tools.StructureUtils;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
@@ -19,9 +25,11 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.sosly.witchcraft.Config;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.factions.FactionRegistry;
 import org.sosly.witchcraft.utils.SympathyHelper;
@@ -71,6 +79,7 @@ public class SympathyRitual extends RitualEffect {
         ItemStack spellItem = getSpellItem(ctx);
         ItemStack boundPoppet = getBoundPoppet(ctx);
         if (spellItem.isEmpty() || boundPoppet.isEmpty()) {
+            player.sendSystemMessage(Component.translatable("rituals.error.no_target"));
             return false;
         }
 
@@ -81,23 +90,31 @@ public class SympathyRitual extends RitualEffect {
 
         Entity target = SympathyHelper.getBoundEntity(boundPoppet, level);
         if (target == null) {
+            player.sendSystemMessage(Component.translatable("rituals.error.no_target"));
+            return false;
+        }
+
+        if (Config.bossesBlockSympathy && isInBossArena(level, target)) {
+            player.sendSystemMessage(Component.translatable("rituals.sympathy.target_protected"));
             return false;
         }
 
         ICanContainSpell spellItemCapability = (ICanContainSpell) spellItem.getItem();
         ISpellDefinition spell = spellItemCapability.getSpell(spellItem, player);
-        if (spell.getShape().equals(SpellsInit.SELF)) {
+        if (spell.getShape() != null && isSelfSpell(spell.getShape().getPart())) {
+            player.sendSystemMessage(Component.translatable("rituals.sympathy.no_self_spells"));
             return false;
         }
 
+        IModifiedSpellPart<Shape> spellShape = spell.getShape();
         SpellSource spellSource = new SpellSource(player, InteractionHand.MAIN_HAND);
         SpellTarget spellTarget = new SpellTarget(target);
         SpellContext spellContext = new SpellContext(level, spell);
 
-        spell.iterateComponents(c ->  {
-            LOGGER.info("{} cast {} on {}.", player.getName().getString(), c.getPart().getRegistryName(),
+        spell.iterateComponents(component ->  {
+            LOGGER.info("{} cast {} on {}.", player.getName().getString(), component.getPart().getRegistryName(),
                     target.getName().getString());
-            c.getPart().ApplyEffect(spellSource, spellTarget, c, spellContext);
+            affectTarget(level, spellShape, spellSource, spellTarget, component, spellContext);
         });
 
         return true;
@@ -121,5 +138,18 @@ public class SympathyRitual extends RitualEffect {
                 .filter(filter::IsValidItem)
                 .findFirst()
                 .orElse(ItemStack.EMPTY);
+    }
+
+    private boolean isInBossArena(ServerLevel level, Entity target) {
+        return StructureUtils.isPointInAnyStructure(level, target.blockPosition(), MATags.Structures.BOSS_ARENAS);
+    }
+
+    private boolean isSelfSpell(Shape part) {
+        return part.equals(SpellsInit.SELF) || part.equals(SpellsInit.BOUND_AXE) || part.equals(SpellsInit.BOUND_SWORD)
+                || part.equals(SpellsInit.BOUND_BOW) || part.equals(SpellsInit.BOUND_SHIELD);
+    }
+
+    private ComponentApplicationResult affectTarget(Level level, IModifiedSpellPart<Shape> shape, SpellSource source, SpellTarget target, IModifiedSpellPart<SpellEffect> effect, SpellContext ctx) {
+        return effect.getPart().ApplyEffect(source, target, effect, ctx);
     }
 }

--- a/src/main/java/org/sosly/witchcraft/rituals/effects/SympathyRitual.java
+++ b/src/main/java/org/sosly/witchcraft/rituals/effects/SympathyRitual.java
@@ -99,6 +99,11 @@ public class SympathyRitual extends RitualEffect {
             return false;
         }
 
+        if (Config.bossesImmuneToSympathy && SympathyHelper.isBoss(target)) {
+            player.sendSystemMessage(Component.translatable("rituals.sympathy.target_protected"));
+            return false;
+        }
+
         ICanContainSpell spellItemCapability = (ICanContainSpell) spellItem.getItem();
         ISpellDefinition spell = spellItemCapability.getSpell(spellItem, player);
         if (spell.getShape() != null && isSelfSpell(spell.getShape().getPart())) {

--- a/src/main/java/org/sosly/witchcraft/utils/SympathyHelper.java
+++ b/src/main/java/org/sosly/witchcraft/utils/SympathyHelper.java
@@ -1,8 +1,11 @@
 package org.sosly.witchcraft.utils;
 
+import com.mna.entities.boss.BossMonster;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
+import net.minecraft.world.entity.boss.wither.WitherBoss;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,6 +15,10 @@ public class SympathyHelper {
     public static boolean isBound(ItemStack item) {
         CompoundTag tag = item.getTag();
         return tag != null && tag.contains("target");
+    }
+
+    public static boolean isBoss(Entity entity) {
+        return (entity instanceof WitherBoss) || (entity instanceof EnderDragon) || (entity instanceof BossMonster);
     }
 
     @Nullable

--- a/src/main/resources/assets/mnaw/lang/en_us.json
+++ b/src/main/resources/assets/mnaw/lang/en_us.json
@@ -11,5 +11,7 @@
   "rituals.error.no_caster": "No player reference found for ritual, aborting.",
   "rituals.error.tier_required": "You must be at least tier %d to perform this ritual.",
   "rituals.error.no_target": "No target found for ritual, aborting.",
-  "rituals.sympathy.not_a_witch": "Only coven witches can perform this ritual."
+  "rituals.sympathy.no_self_spells": "Sympathetic magic does not work with spells that target yourself.",
+  "rituals.sympathy.not_a_witch": "Only coven witches can perform this ritual.",
+  "rituals.sympathy.target_protected": "Something is protecting your target."
 }


### PR DESCRIPTION
If the configuration value is set to true, targets in boss arenas will be fully protected from sympathetic magic.  This setting defaults to true.

Resolves #26.