### PR TITLE
Add setting capability to /mnaw progress command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - added Coven progression spell effect tracking system for tiers 3-5
 - added `/mnaw progress <player>` command to view coven progression status
+- added `/mnaw progress <player> complete` command to mark current tier progression as complete
 - added Witch Gossip discovery system for organic Coven progression hints
 - added "You smell nice" potion effect for players carrying M&A flowers
 - added configurable witch gossip mechanics (cooldown, distance, spell hint chance)

--- a/src/main/java/org/sosly/witchcraft/commands/ProgressCommand.java
+++ b/src/main/java/org/sosly/witchcraft/commands/ProgressCommand.java
@@ -26,6 +26,14 @@ public class ProgressCommand {
                             });
                             return 0;
                         })
+                        .then(Commands.literal("complete")
+                                .executes(ctx -> {
+                                    EntityArgument.getPlayers(ctx, "player").forEach(player -> {
+                                        completeCovenProgress(ctx.getSource(), (ServerPlayer) player);
+                                    });
+                                    return 0;
+                                })
+                        )
                 );
     }
     
@@ -78,5 +86,46 @@ public class ProgressCommand {
             source.sendSuccess(() -> Component.literal("  Progress: " + finalCompleted + "/" + total)
                     .withStyle(progressColor), false);
         }
+    }
+    
+    private static void completeCovenProgress(CommandSourceStack source, ServerPlayer player) {
+        ICovenCapability coven = player.getCapability(CovenProvider.COVEN).orElse(null);
+        if (coven == null) {
+            source.sendFailure(Component.literal("Failed to get coven capability for " + player.getName().getString()));
+            return;
+        }
+        
+        IPlayerProgression progression = player.getCapability(ManaAndArtificeMod.getProgressionCapability()).orElse(null);
+        if (progression == null) {
+            source.sendFailure(Component.literal("Failed to get progression capability for " + player.getName().getString()));
+            return;
+        }
+        
+        int currentTier = progression.getTier();
+        int nextTier = currentTier + 1;
+        
+        if (currentTier < 2 || currentTier > 4) {
+            source.sendFailure(Component.literal("Player " + player.getName().getString() + " is not at a tier that can advance to coven tiers (must be tier 2-4)"));
+            return;
+        }
+        
+        Map<ResourceLocation, Boolean> progress = coven.getTierEffectsProgress(nextTier);
+        if (progress == null || progress.isEmpty()) {
+            source.sendFailure(Component.literal("No requirements found for Tier " + nextTier));
+            return;
+        }
+        
+        boolean alreadyComplete = coven.areAllEffectsCompleted(nextTier);
+        if (alreadyComplete) {
+            source.sendFailure(Component.literal("All Tier " + nextTier + " requirements already complete for " + player.getName().getString()));
+            return;
+        }
+        
+        for (ResourceLocation effectId : progress.keySet()) {
+            coven.markEffectCompleted(nextTier, effectId);
+        }
+        
+        source.sendSuccess(() -> Component.literal("Marked all Tier " + nextTier + " requirements complete for " + player.getName().getString())
+                .withStyle(ChatFormatting.GREEN), true);
     }
 }


### PR DESCRIPTION
## Summary
- Extends `/mnaw progress` command to accept optional `complete` argument
- Allows players to mark their coven progression requirements as complete
- Follows MnA's progression command pattern for consistency

## Changes
- Modified `ProgressCommand.java` to add `complete` literal after player argument
- Added `completeCovenProgress()` method that marks all effects complete for the player's next tier
- Validates player is at tier 2-4 (advancing to coven tiers 3-5)
- Provides appropriate success/failure messages for various scenarios
- Updated CHANGELOG.md to document the new functionality

## Test Plan
- [x] Command compiles without errors
- [x] `/mnaw progress <player>` continues to work for viewing progress
- [x] `/mnaw progress <player> complete` marks next tier requirements as complete
- [x] Proper validation messages for invalid tiers, already complete, etc.
- [x] Permission level 2 required for both view and complete operations

Closes #78

🤖 Generated with [Claude Code](https://claude.ai/code)