### PR TITLE
Move configuration from client-side to server-side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added "You smell nice" potion effect for players carrying M&A flowers
 - added configurable witch gossip mechanics (cooldown, distance, spell hint chance)
 
+### Changed
+- migrated configuration from client-side to server-side (per-world configuration)
+
 ## [1.20.1-forge-0.2.1-alpha](https://github.com/SoSly/MnAWitchcraft/releases/tag/1.20.1-forge-0.2.1-alpha)
 ### Fixed
 - removed a naughty comma from the potion pouch guide entry which was causing codex crashes

--- a/src/main/java/org/sosly/witchcraft/ServerConfig.java
+++ b/src/main/java/org/sosly/witchcraft/ServerConfig.java
@@ -5,10 +5,10 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.config.ModConfigEvent;
 
-// An example config class. This is not required, but it's a good idea to have one to keep your config organized.
-// Demonstrates how to use Forge's config APIs
+// Server-side configuration for MNAW mod
+// These settings are stored per-world and synced from server to clients
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
-public class Config {
+public class ServerConfig {
     private static final ForgeConfigSpec.Builder BUILDER = new ForgeConfigSpec.Builder();
 
     private static final ForgeConfigSpec.BooleanValue BOSSES_BLOCK_SYMPATHY = BUILDER

--- a/src/main/java/org/sosly/witchcraft/Witchcraft.java
+++ b/src/main/java/org/sosly/witchcraft/Witchcraft.java
@@ -41,7 +41,7 @@ public class Witchcraft {
         MinecraftForge.EVENT_BUS.register(this);
 
         // Register our mod's ForgeConfigSpec so that Forge can create and load the config file for us
-        ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.SPEC);
+        ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, ServerConfig.SPEC);
 
         if (FMLEnvironment.dist.isClient()) {
             modbus.register(ScreenRegistry.class);

--- a/src/main/java/org/sosly/witchcraft/enchantments/staves/DedicationEnchantment.java
+++ b/src/main/java/org/sosly/witchcraft/enchantments/staves/DedicationEnchantment.java
@@ -9,7 +9,7 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.EnchantmentCategory;
-import org.sosly.witchcraft.Config;
+import org.sosly.witchcraft.ServerConfig;
 
 public class DedicationEnchantment extends MAEnchantmentBase {
     private static final int chargeModifier = 40;
@@ -44,8 +44,8 @@ public class DedicationEnchantment extends MAEnchantmentBase {
 
         stack.getOrCreateTag().putInt("dedication", level);
 
-        float tierModifier = 1.0F + ((level - 1) * (float)Config.dedicationTierMultiplier);
-        float charges = Config.dedicationCharges * chargeModifier * tierModifier;
+        float tierModifier = 1.0F + ((level - 1) * (float)ServerConfig.dedicationTierMultiplier);
+        float charges = ServerConfig.dedicationCharges * chargeModifier * tierModifier;
         if (ItemUtils.getCharges(stack) == 0) {
             ItemUtils.writeCharges(stack, (int) charges);
         }

--- a/src/main/java/org/sosly/witchcraft/events/entities/WitchGossip.java
+++ b/src/main/java/org/sosly/witchcraft/events/entities/WitchGossip.java
@@ -12,7 +12,7 @@ import net.minecraft.world.phys.AABB;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import org.sosly.witchcraft.Config;
+import org.sosly.witchcraft.ServerConfig;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.effects.EffectRegistry;
 import org.sosly.witchcraft.factions.FactionRegistry;
@@ -42,7 +42,7 @@ public class WitchGossip {
         
         long currentTime = level.getGameTime();
         long lastGossipTime = witch.getPersistentData().getLong(LAST_GOSSIP_TIME_KEY);
-        int cooldownTicks = Config.witchGossipCooldown * 20;
+        int cooldownTicks = ServerConfig.witchGossipCooldown * 20;
         
         if (lastGossipTime != 0 && currentTime - lastGossipTime < cooldownTicks) {
             return;
@@ -53,7 +53,7 @@ public class WitchGossip {
         }
         
         double attackRange = getWitchAttackRange(witch);
-        double gossipRange = Config.witchGossipDistance;
+        double gossipRange = ServerConfig.witchGossipDistance;
         AABB gossipBox = witch.getBoundingBox().inflate(gossipRange);
         List<Player> playersInRange = level.getEntitiesOfClass(Player.class, gossipBox);
         

--- a/src/main/java/org/sosly/witchcraft/events/items/VinteumNeedle.java
+++ b/src/main/java/org/sosly/witchcraft/events/items/VinteumNeedle.java
@@ -11,7 +11,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import org.sosly.witchcraft.Config;
+import org.sosly.witchcraft.ServerConfig;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.items.ItemRegistry;
 import org.sosly.witchcraft.utils.SympathyHelper;
@@ -35,7 +35,7 @@ public class VinteumNeedle {
             return;
         }
 
-        if (Config.bossesImmuneToSympathy && SympathyHelper.isBoss(target)) {
+        if (ServerConfig.bossesImmuneToSympathy && SympathyHelper.isBoss(target)) {
             return;
         }
 

--- a/src/main/java/org/sosly/witchcraft/items/alchemy/PotionPouchItem.java
+++ b/src/main/java/org/sosly/witchcraft/items/alchemy/PotionPouchItem.java
@@ -30,7 +30,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import org.jetbrains.annotations.NotNull;
-import org.sosly.witchcraft.Config;
+import org.sosly.witchcraft.ServerConfig;
 import org.sosly.witchcraft.guis.providers.PotionPouchProvider;
 import org.sosly.witchcraft.inventories.PotionPouchInventory;
 import org.sosly.witchcraft.utils.SympathyHelper;
@@ -156,12 +156,12 @@ public class PotionPouchItem extends ItemBagBase implements IRadialInventorySele
             UUID targetUUID = pouch.getOrCreateTag().getUUID("conveyance_target");
             Player playerTarget = level.getPlayerByUUID(targetUUID);
             if (playerTarget != null) {
-                if (Config.bossesBlockSympathy && SympathyHelper.isInBossArena((ServerLevel) level, target)) {
+                if (ServerConfig.bossesBlockSympathy && SympathyHelper.isInBossArena((ServerLevel) level, target)) {
                     target.sendSystemMessage(Component.translatable("rituals.sympathy.target_protected"));
                     return pouch;
                 }
 
-                if (Config.bossesImmuneToSympathy && SympathyHelper.isBoss(target)) {
+                if (ServerConfig.bossesImmuneToSympathy && SympathyHelper.isBoss(target)) {
                     target.sendSystemMessage(Component.translatable("rituals.sympathy.target_protected"));
                     return pouch;
                 }

--- a/src/main/java/org/sosly/witchcraft/rituals/effects/SympathyRitual.java
+++ b/src/main/java/org/sosly/witchcraft/rituals/effects/SympathyRitual.java
@@ -38,7 +38,7 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.sosly.witchcraft.Config;
+import org.sosly.witchcraft.ServerConfig;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.effects.beneficial.BrokenSympathyEffect;
 import org.sosly.witchcraft.factions.FactionRegistry;
@@ -122,12 +122,12 @@ public class SympathyRitual extends RitualEffect {
             return false;
         }
 
-        if (Config.bossesBlockSympathy && SympathyHelper.isInBossArena(level, target)) {
+        if (ServerConfig.bossesBlockSympathy && SympathyHelper.isInBossArena(level, target)) {
             player.sendSystemMessage(Component.translatable("rituals.sympathy.target_protected"));
             return false;
         }
 
-        if (Config.bossesImmuneToSympathy && SympathyHelper.isBoss(target)) {
+        if (ServerConfig.bossesImmuneToSympathy && SympathyHelper.isBoss(target)) {
             player.sendSystemMessage(Component.translatable("rituals.sympathy.target_protected"));
             return false;
         }

--- a/src/main/java/org/sosly/witchcraft/utils/GossipMessageGenerator.java
+++ b/src/main/java/org/sosly/witchcraft/utils/GossipMessageGenerator.java
@@ -5,7 +5,7 @@ import com.mna.capabilities.playerdata.progression.PlayerProgressionProvider;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
-import org.sosly.witchcraft.Config;
+import org.sosly.witchcraft.ServerConfig;
 import org.sosly.witchcraft.api.capabilities.ICovenCapability;
 import org.sosly.witchcraft.capabilities.coven.CovenProvider;
 
@@ -60,7 +60,7 @@ public class GossipMessageGenerator {
             return generateRitualHintGossip(scentedItem, player);
         }
         
-        if (player.getRandom().nextInt(Config.witchGossipSpellHintChance) != 0) {
+        if (player.getRandom().nextInt(ServerConfig.witchGossipSpellHintChance) != 0) {
             return generateNonSpellGossip(scentedItem, player);
         }
         


### PR DESCRIPTION
## Summary
Migrates MNAW configuration from client-side to server-side, ensuring consistent settings across all players on a server.

## Changes
- Changed `ModConfig.Type.COMMON` to `ModConfig.Type.SERVER` 
- Renamed `Config.java` to `ServerConfig.java` for clarity
- Updated all imports and references throughout the codebase
- Configuration now generates in `saves/<world>/serverconfig/mnaw-server.toml`
- Each world can have independent mod settings
- Settings automatically sync from server to clients

## Testing
- [x] Configuration generates in correct location (`saves/<world>/serverconfig/`)
- [x] All existing configuration options work correctly
- [x] No compilation errors
- [x] Multiplayer sync verification

Closes #79

🤖 Generated with [Claude Code](https://claude.ai/code)