### PR TITLE
refactor: add comprehensive logging and refactor broom capability access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bloody needles and bound poppets now display who they are bound to in their tooltip 
 - dedicated items can be recharged by right-clicking a crucible prepared with instant mana or mana regen effects
 - dedicated items will resist expending their last charge
+- added comprehensive logging throughout the mod for better error tracking and debugging
 
 ### Fixed
 - fixed a typo in the factionless mages codex entry

--- a/src/main/java/org/sosly/witchcraft/Witchcraft.java
+++ b/src/main/java/org/sosly/witchcraft/Witchcraft.java
@@ -1,6 +1,7 @@
 package org.sosly.witchcraft;
 
 import com.mna.api.guidebook.RegisterGuidebooksEvent;
+import com.mojang.logging.LogUtils;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -11,8 +12,7 @@ import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLEnvironment;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.blocks.BlockRegistry;
 import org.sosly.witchcraft.blocks.EntityRegistry;
 import org.sosly.witchcraft.commands.CommandRegistry;
@@ -30,9 +30,10 @@ import org.sosly.witchcraft.cantrips.Cantrips;
 @Mod(Witchcraft.MOD_ID)
 public class Witchcraft {
     public static final String MOD_ID = "mnaw";
-    public static final Logger LOGGER = LogManager.getLogger();
+    public static final Logger LOGGER = LogUtils.getLogger();
 
     public Witchcraft() {
+        LOGGER.info("Initializing M&A Witchcraft mod");
         IEventBus modbus = FMLJavaModLoadingContext.get().getModEventBus();
 
         BlockRegistry.BLOCKS.register(modbus);
@@ -54,18 +55,22 @@ public class Witchcraft {
 
         if (FMLEnvironment.dist.isClient()) {
             modbus.register(ScreenRegistry.class);
+            LOGGER.info("Registered client-side screen handlers");
         }
+        LOGGER.info("M&A Witchcraft mod initialization complete");
     }
 
     private void commonSetup(FMLCommonSetupEvent event) {
+        LOGGER.info("Beginning common setup phase");
         event.enqueueWork(() -> {
             Cantrips.registerCantrips();
+            LOGGER.info("Cantrips registered successfully");
         });
     }
 
     @SubscribeEvent
     public void onRegisterGuidebooks(RegisterGuidebooksEvent event) {
         event.getRegistry().addGuidebookPath(new ResourceLocation(MOD_ID, "guide"));
-        LOGGER.info("guide registered");
+        LOGGER.info("Witchcraft guidebook registered");
     }
 }

--- a/src/main/java/org/sosly/witchcraft/blocks/alchemy/AbstractWitchsCauldronBlock.java
+++ b/src/main/java/org/sosly/witchcraft/blocks/alchemy/AbstractWitchsCauldronBlock.java
@@ -1,5 +1,6 @@
 package org.sosly.witchcraft.blocks.alchemy;
 
+import com.mojang.logging.LogUtils;
 import com.mysticalchemy.crucible.BlockCrucible;
 import net.minecraft.core.BlockPos;
 import net.minecraft.sounds.SoundEvents;
@@ -30,6 +31,7 @@ import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraft.util.RandomSource;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.blocks.EntityRegistry;
 import org.sosly.witchcraft.fluids.FluidRegistry;
 import org.sosly.witchcraft.items.ItemRegistry;
@@ -55,6 +57,7 @@ import java.util.List;
  * LEVEL = 0, so we need a separate block for the empty state.
  */
 public abstract class AbstractWitchsCauldronBlock extends BlockCrucible implements EntityBlock {
+    private static final Logger LOGGER = LogUtils.getLogger();
     public static final IntegerProperty LEVEL = LayeredCauldronBlock.LEVEL;
     
     private static final VoxelShape INSIDE = box(2.0D, 4.0D, 2.0D, 14.0D, 16.0D, 14.0D);
@@ -180,6 +183,7 @@ public abstract class AbstractWitchsCauldronBlock extends BlockCrucible implemen
         BlockEntity blockEntity = level.getBlockEntity(pos);
         
         if (!(blockEntity instanceof WitchsCauldronBlockEntity cauldron)) {
+            LOGGER.warn("AbstractWitchsCauldronBlock at {} does not have WitchsCauldronBlockEntity, falling back to super.use()", pos);
             return super.use(state, level, pos, player, hand, hit);
         }
         

--- a/src/main/java/org/sosly/witchcraft/blocks/alchemy/WitchsCauldronBlockEntity.java
+++ b/src/main/java/org/sosly/witchcraft/blocks/alchemy/WitchsCauldronBlockEntity.java
@@ -224,16 +224,8 @@ public class WitchsCauldronBlockEntity extends BlockEntity {
     public void load(@NotNull CompoundTag tag) {
         super.load(tag);
         String fluidTypeString = tag.getString("FluidType");
-        if (fluidTypeString.isEmpty()) {
-            LOGGER.warn("WitchsCauldronBlockEntity at {} has empty FluidType in NBT, defaulting to EMPTY", worldPosition);
-            fluidType = FluidType.EMPTY;
-        } else {
-            try {
-                fluidType = FluidType.valueOf(fluidTypeString);
-            } catch (IllegalArgumentException e) {
-                LOGGER.error("WitchsCauldronBlockEntity at {} has invalid FluidType '{}' in NBT, defaulting to EMPTY", worldPosition, fluidTypeString);
-                fluidType = FluidType.EMPTY;
-            }
+        if (!fluidTypeString.isEmpty()) {
+            fluidType = FluidType.valueOf(fluidTypeString);
         }
         fluidLevel = tag.getInt("FluidLevel");
         if (tag.contains("heat")) {

--- a/src/main/java/org/sosly/witchcraft/blocks/alchemy/WitchsCauldronBlockEntity.java
+++ b/src/main/java/org/sosly/witchcraft/blocks/alchemy/WitchsCauldronBlockEntity.java
@@ -1,5 +1,6 @@
 package org.sosly.witchcraft.blocks.alchemy;
 
+import com.mojang.logging.LogUtils;
 import com.mysticalchemy.config.BrewingConfig;
 import com.mysticalchemy.init.RecipeInit;
 import com.mysticalchemy.recipe.PotionIngredientRecipe;
@@ -31,6 +32,7 @@ import net.minecraft.world.level.material.Fluids;
 import net.minecraftforge.client.model.data.ModelData;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.blocks.BlockRegistry;
 import org.sosly.witchcraft.blocks.EntityRegistry;
 import org.sosly.witchcraft.fluids.FluidRegistry;
@@ -39,6 +41,7 @@ import java.util.HashMap;
 import java.util.Optional;
 
 public class WitchsCauldronBlockEntity extends BlockEntity {
+    private static final Logger LOGGER = LogUtils.getLogger();
     
     public enum FluidType {
         EMPTY(null),
@@ -220,7 +223,18 @@ public class WitchsCauldronBlockEntity extends BlockEntity {
     @Override
     public void load(@NotNull CompoundTag tag) {
         super.load(tag);
-        fluidType = FluidType.valueOf(tag.getString("FluidType"));
+        String fluidTypeString = tag.getString("FluidType");
+        if (fluidTypeString.isEmpty()) {
+            LOGGER.warn("WitchsCauldronBlockEntity at {} has empty FluidType in NBT, defaulting to EMPTY", worldPosition);
+            fluidType = FluidType.EMPTY;
+        } else {
+            try {
+                fluidType = FluidType.valueOf(fluidTypeString);
+            } catch (IllegalArgumentException e) {
+                LOGGER.error("WitchsCauldronBlockEntity at {} has invalid FluidType '{}' in NBT, defaulting to EMPTY", worldPosition, fluidTypeString);
+                fluidType = FluidType.EMPTY;
+            }
+        }
         fluidLevel = tag.getInt("FluidLevel");
         if (tag.contains("heat")) {
             heat = tag.getFloat("heat");
@@ -246,8 +260,10 @@ public class WitchsCauldronBlockEntity extends BlockEntity {
                     continue;
                 }
                 
-                MobEffect e = ForgeRegistries.MOB_EFFECTS.getValue(new ResourceLocation(tag.getString("effect" + i)));
+                String effectString = tag.getString("effect" + i);
+                MobEffect e = ForgeRegistries.MOB_EFFECTS.getValue(new ResourceLocation(effectString));
                 if (e == null) {
+                    LOGGER.warn("WitchsCauldronBlockEntity at {} failed to load effect '{}' from NBT", worldPosition, effectString);
                     continue;
                 }
                 
@@ -399,6 +415,7 @@ public class WitchsCauldronBlockEntity extends BlockEntity {
             recipeManager = level.getRecipeManager();
         }
         if (recipeManager == null) {
+            LOGGER.error("WitchsCauldronBlockEntity at {} failed to get RecipeManager when trying to add ingredient", worldPosition);
             return false;
         }
         
@@ -612,14 +629,22 @@ public class WitchsCauldronBlockEntity extends BlockEntity {
     }
     
     private void switchToEmptyCauldron() {
-        if (level == null || level.isClientSide) {
+        if (level == null) {
+            LOGGER.error("WitchsCauldronBlockEntity at {} tried to switch to empty cauldron but level is null", worldPosition);
+            return;
+        }
+        if (level.isClientSide) {
             return;
         }
         CauldronStateManager.switchToEmptyBlock(level, worldPosition, this);
     }
     
     private void switchToFilledCauldron() {
-        if (level == null || level.isClientSide) {
+        if (level == null) {
+            LOGGER.error("WitchsCauldronBlockEntity at {} tried to switch to filled cauldron but level is null", worldPosition);
+            return;
+        }
+        if (level.isClientSide) {
             return;
         }
         CauldronStateManager.switchToFilledBlock(level, worldPosition, this, fluidType, fluidLevel);

--- a/src/main/java/org/sosly/witchcraft/blocks/entities/BoundPoppetEntity.java
+++ b/src/main/java/org/sosly/witchcraft/blocks/entities/BoundPoppetEntity.java
@@ -1,15 +1,19 @@
 package org.sosly.witchcraft.blocks.entities;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.blocks.EntityRegistry;
 
 import java.util.UUID;
 
 public class BoundPoppetEntity extends BlockEntity {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    
     UUID target;
     String type;
 
@@ -27,15 +31,29 @@ public class BoundPoppetEntity extends BlockEntity {
 
     @Override
     protected void saveAdditional(CompoundTag tag) {
-        tag.putUUID("target", target);
-        tag.putString("type", type);
+        if (target != null) {
+            tag.putUUID("target", target);
+        }
+        if (type != null) {
+            tag.putString("type", type);
+        }
         super.saveAdditional(tag);
     }
 
     @Override
     public void load(@NotNull CompoundTag tag) {
-        target = tag.getUUID("target");
-        type = tag.getString("type");
+        if (tag.hasUUID("target")) {
+            target = tag.getUUID("target");
+        } else {
+            LOGGER.warn("BoundPoppetEntity at {} loaded without target UUID", worldPosition);
+            target = null;
+        }
+        if (tag.contains("type")) {
+            type = tag.getString("type");
+        } else {
+            LOGGER.warn("BoundPoppetEntity at {} loaded without type string", worldPosition);
+            type = null;
+        }
         super.load(tag);
     }
 }

--- a/src/main/java/org/sosly/witchcraft/blocks/entities/BoundPoppetEntity.java
+++ b/src/main/java/org/sosly/witchcraft/blocks/entities/BoundPoppetEntity.java
@@ -44,15 +44,9 @@ public class BoundPoppetEntity extends BlockEntity {
     public void load(@NotNull CompoundTag tag) {
         if (tag.hasUUID("target")) {
             target = tag.getUUID("target");
-        } else {
-            LOGGER.warn("BoundPoppetEntity at {} loaded without target UUID", worldPosition);
-            target = null;
         }
         if (tag.contains("type")) {
             type = tag.getString("type");
-        } else {
-            LOGGER.warn("BoundPoppetEntity at {} loaded without type string", worldPosition);
-            type = null;
         }
         super.load(tag);
     }

--- a/src/main/java/org/sosly/witchcraft/blocks/sympathy/BoundPoppetBlock.java
+++ b/src/main/java/org/sosly/witchcraft/blocks/sympathy/BoundPoppetBlock.java
@@ -1,5 +1,6 @@
 package org.sosly.witchcraft.blocks.sympathy;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.LivingEntity;
@@ -9,13 +10,22 @@ import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.blocks.entities.BoundPoppetEntity;
 
 public class BoundPoppetBlock extends PoppetBlock implements EntityBlock {
+    private static final Logger LOGGER = LogUtils.getLogger();
+
     public void setPlacedBy(Level level, BlockPos pos, BlockState state, LivingEntity placer, ItemStack stack) {
         CompoundTag tag = stack.getTag();
         BoundPoppetEntity be = (BoundPoppetEntity) level.getBlockEntity(pos);
-        if (be == null || tag == null) {
+        if (be == null) {
+            LOGGER.error("Failed to get BoundPoppetEntity at {} during block placement", pos);
+            super.setPlacedBy(level, pos, state, placer, stack);
+            return;
+        }
+        if (tag == null) {
+            LOGGER.warn("BoundPoppetBlock placed without NBT data at {} - creating empty bound poppet", pos);
             super.setPlacedBy(level, pos, state, placer, stack);
             return;
         }

--- a/src/main/java/org/sosly/witchcraft/blocks/sympathy/PoppetBlock.java
+++ b/src/main/java/org/sosly/witchcraft/blocks/sympathy/PoppetBlock.java
@@ -1,5 +1,6 @@
 package org.sosly.witchcraft.blocks.sympathy;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
@@ -22,6 +23,7 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.registries.ForgeRegistries;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.blocks.entities.BoundPoppetEntity;
 import org.sosly.witchcraft.items.sympathy.BoundPoppetItem;
 
@@ -29,6 +31,8 @@ import java.util.UUID;
 
 
 public class PoppetBlock extends HorizontalDirectionalBlock implements SimpleWaterloggedBlock {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    
     public PoppetBlock(Properties properties) {
         super(properties);
         registerDefaultState(stateDefinition.any()
@@ -95,10 +99,15 @@ public class PoppetBlock extends HorizontalDirectionalBlock implements SimpleWat
 
         ResourceLocation key = ForgeRegistries.BLOCKS.getKey(this);
         if (key == null) {
+            LOGGER.error("Failed to get registry key for PoppetBlock during destruction at {}", pos);
             return;
         }
         
         Item boundPoppetItem = ForgeRegistries.ITEMS.getValue(key);
+        if (boundPoppetItem == null) {
+            LOGGER.error("Failed to get item for block {} during destruction at {}", key, pos);
+            return;
+        }
         ItemStack stack = new ItemStack(boundPoppetItem);
 
         if (!(blockEntity instanceof BoundPoppetEntity boundPoppet)) {

--- a/src/main/java/org/sosly/witchcraft/capabilities/CapabilityRegistry.java
+++ b/src/main/java/org/sosly/witchcraft/capabilities/CapabilityRegistry.java
@@ -1,8 +1,10 @@
 package org.sosly.witchcraft.capabilities;
 
+import com.mojang.logging.LogUtils;
 import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.api.capabilities.IBroomCapability;
 import org.sosly.witchcraft.api.capabilities.ICovenCapability;
@@ -10,6 +12,8 @@ import org.sosly.witchcraft.api.capabilities.IMoonthreadArmorData;
 
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class CapabilityRegistry {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    
     @SubscribeEvent
     public static void registerCapabilities(RegisterCapabilitiesEvent event) {
         event.register(IBroomCapability.class);

--- a/src/main/java/org/sosly/witchcraft/capabilities/broom/BroomProvider.java
+++ b/src/main/java/org/sosly/witchcraft/capabilities/broom/BroomProvider.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.sosly.witchcraft.api.capabilities.IBroomCapability;
 
+import java.util.Objects;
 import java.util.UUID;
 
 public class BroomProvider implements ICapabilitySerializable<Tag> {
@@ -99,7 +100,7 @@ public class BroomProvider implements ICapabilitySerializable<Tag> {
             return null;
         }
         
-        if (!broomId.equals(broom.getBondedBroomId())) {
+        if (!Objects.equals(broomId, broom.getBondedBroomId())) {
             LOGGER.warn("Player {} trying to access broom they are not bonded to", player.getName().getString());
             return null;
         }

--- a/src/main/java/org/sosly/witchcraft/capabilities/broom/BroomProvider.java
+++ b/src/main/java/org/sosly/witchcraft/capabilities/broom/BroomProvider.java
@@ -1,10 +1,12 @@
 package org.sosly.witchcraft.capabilities.broom;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.CapabilityToken;
@@ -12,9 +14,13 @@ import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 import net.minecraftforge.common.util.LazyOptional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.api.capabilities.IBroomCapability;
 
+import java.util.UUID;
+
 public class BroomProvider implements ICapabilitySerializable<Tag> {
+    private static final Logger LOGGER = LogUtils.getLogger();
     public static final Capability<IBroomCapability> BROOM = CapabilityManager.get(new CapabilityToken<>() {});
     private final LazyOptional<IBroomCapability> holder = LazyOptional.of(BroomCapability::new);
 
@@ -44,6 +50,7 @@ public class BroomProvider implements ICapabilitySerializable<Tag> {
         IBroomCapability instance = holder.orElse(new BroomCapability());
         
         if (!(nbt instanceof CompoundTag cnbt)) {
+            LOGGER.warn("Invalid NBT type for broom capability deserialization");
             return;
         }
         
@@ -62,5 +69,41 @@ public class BroomProvider implements ICapabilitySerializable<Tag> {
     @Override
     public @NotNull <T> LazyOptional<T> getCapability(@NotNull Capability<T> cap, @Nullable Direction side) {
         return BROOM.orEmpty(cap, holder);
+    }
+
+    @Nullable
+    public static IBroomCapability getBroomCapability(Player player) {
+        if (player == null) {
+            LOGGER.warn("Cannot get broom capability: player is null");
+            return null;
+        }
+        
+        LazyOptional<IBroomCapability> cap = player.getCapability(BROOM);
+        if (!cap.isPresent()) {
+            LOGGER.warn("Player {} missing broom capability", player.getName().getString());
+            return null;
+        }
+        
+        return cap.resolve().orElse(null);
+    }
+
+    @Nullable
+    public static IBroomCapability getBroomCapability(Player player, UUID broomId) {
+        IBroomCapability broom = getBroomCapability(player);
+        if (broom == null) {
+            return null;
+        }
+        
+        if (broomId == null) {
+            LOGGER.warn("Cannot validate broom bond: broomId is null");
+            return null;
+        }
+        
+        if (!broomId.equals(broom.getBondedBroomId())) {
+            LOGGER.warn("Player {} trying to access broom they are not bonded to", player.getName().getString());
+            return null;
+        }
+        
+        return broom;
     }
 }

--- a/src/main/java/org/sosly/witchcraft/capabilities/coven/CovenCapability.java
+++ b/src/main/java/org/sosly/witchcraft/capabilities/coven/CovenCapability.java
@@ -1,6 +1,8 @@
 package org.sosly.witchcraft.capabilities.coven;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.resources.ResourceLocation;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.api.capabilities.ICovenCapability;
 
 import java.util.Collection;
@@ -9,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class CovenCapability implements ICovenCapability {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private boolean malice = false;
     private final Map<Integer, Map<ResourceLocation, Boolean>> tierEffectsProgress = new HashMap<>();
 
@@ -35,6 +38,11 @@ public class CovenCapability implements ICovenCapability {
 
     @Override
     public void setTierEffectsRequired(int tier, Set<ResourceLocation> effects) {
+        if (effects == null || effects.isEmpty()) {
+            LOGGER.warn("Attempted to set null or empty effects for tier {}", tier);
+            return;
+        }
+        
         Map<ResourceLocation, Boolean> progress = new HashMap<>();
 
         for (ResourceLocation effect : effects) {
@@ -48,9 +56,17 @@ public class CovenCapability implements ICovenCapability {
     public void markEffectCompleted(int tier, ResourceLocation effectId) {
         Map<ResourceLocation, Boolean> progress = tierEffectsProgress.get(tier);
 
-        if (progress != null && progress.containsKey(effectId)) {
-            progress.put(effectId, true);
+        if (progress == null) {
+            LOGGER.warn("Attempted to mark effect {} completed for tier {} but no progress map exists", effectId, tier);
+            return;
         }
+        
+        if (!progress.containsKey(effectId)) {
+            LOGGER.warn("Attempted to mark unknown effect {} completed for tier {}", effectId, tier);
+            return;
+        }
+        
+        progress.put(effectId, true);
     }
 
     @Override

--- a/src/main/java/org/sosly/witchcraft/capabilities/coven/CovenProvider.java
+++ b/src/main/java/org/sosly/witchcraft/capabilities/coven/CovenProvider.java
@@ -1,5 +1,6 @@
 package org.sosly.witchcraft.capabilities.coven;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
@@ -11,6 +12,7 @@ import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 import net.minecraftforge.common.util.LazyOptional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.api.capabilities.ICovenCapability;
 
 import java.util.HashSet;
@@ -19,6 +21,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class CovenProvider implements ICapabilitySerializable<Tag> {
+    private static final Logger LOGGER = LogUtils.getLogger();
     public static final Capability<ICovenCapability> COVEN = CapabilityManager.get(new CapabilityToken<>() {});
     private final LazyOptional<ICovenCapability> holder = LazyOptional.of(CovenCapability::new);
 
@@ -57,6 +60,7 @@ public class CovenProvider implements ICapabilitySerializable<Tag> {
         ICovenCapability instance = holder.orElse(new CovenCapability());
         
         if (!(nbt instanceof CompoundTag cnbt)) {
+            LOGGER.warn("Invalid NBT type for coven capability deserialization");
             return;
         }
         

--- a/src/main/java/org/sosly/witchcraft/commands/MaliceCommand.java
+++ b/src/main/java/org/sosly/witchcraft/commands/MaliceCommand.java
@@ -4,15 +4,19 @@ import com.mna.api.ManaAndArtificeMod;
 import com.mna.api.capabilities.IPlayerProgression;
 import com.mna.capabilities.playerdata.progression.PlayerProgression;
 import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.logging.LogUtils;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.EntityArgument;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.api.capabilities.ICovenCapability;
 import org.sosly.witchcraft.capabilities.coven.CovenCapability;
 import org.sosly.witchcraft.capabilities.coven.CovenProvider;
 import org.sosly.witchcraft.factions.FactionRegistry;
 
 public class MaliceCommand {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    
     public static ArgumentBuilder<CommandSourceStack, ?> register() {
         return Commands.literal("malice")
                 .requires(source -> source.hasPermission(2))
@@ -27,11 +31,13 @@ public class MaliceCommand {
                                 ICovenCapability coven = player.getCapability(CovenProvider.COVEN).orElse(new CovenCapability());
                                 boolean malice = !coven.hasMalice();
                                 coven.setMalice(malice);
+                                LOGGER.info("MaliceCommand: Set malice to {} for player {}", malice, player.getName().getString());
                                 if (!malice) {
                                     return;
                                 }
                                 
                                 progress.setAlliedFaction(FactionRegistry.DARK_COVEN, player);
+                                LOGGER.info("MaliceCommand: Set player {} to Dark Coven faction", player.getName().getString());
                             });
                             return 0;
                         })

--- a/src/main/java/org/sosly/witchcraft/commands/ProgressCommand.java
+++ b/src/main/java/org/sosly/witchcraft/commands/ProgressCommand.java
@@ -3,6 +3,7 @@ package org.sosly.witchcraft.commands;
 import com.mna.api.ManaAndArtificeMod;
 import com.mna.api.capabilities.IPlayerProgression;
 import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.logging.LogUtils;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -10,12 +11,15 @@ import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.api.capabilities.ICovenCapability;
 import org.sosly.witchcraft.capabilities.coven.CovenProvider;
 
 import java.util.Map;
 
 public class ProgressCommand {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    
     public static ArgumentBuilder<CommandSourceStack, ?> register() {
         return Commands.literal("progress")
                 .requires(source -> source.hasPermission(2))
@@ -40,12 +44,14 @@ public class ProgressCommand {
     private static void showCovenProgress(CommandSourceStack source, ServerPlayer player) {
         ICovenCapability coven = player.getCapability(CovenProvider.COVEN).orElse(null);
         if (coven == null) {
+            LOGGER.error("ProgressCommand: Failed to get coven capability for player {}", player.getName().getString());
             source.sendFailure(Component.literal("Failed to get coven capability for " + player.getName().getString()));
             return;
         }
         
         IPlayerProgression progression = player.getCapability(ManaAndArtificeMod.getProgressionCapability()).orElse(null);
         if (progression == null) {
+            LOGGER.error("ProgressCommand: Failed to get progression capability for player {}", player.getName().getString());
             source.sendFailure(Component.literal("Failed to get progression capability for " + player.getName().getString()));
             return;
         }
@@ -93,12 +99,14 @@ public class ProgressCommand {
     private static void completeCovenProgress(CommandSourceStack source, ServerPlayer player) {
         ICovenCapability coven = player.getCapability(CovenProvider.COVEN).orElse(null);
         if (coven == null) {
+            LOGGER.error("ProgressCommand: Failed to get coven capability for player {} during completion", player.getName().getString());
             source.sendFailure(Component.literal("Failed to get coven capability for " + player.getName().getString()));
             return;
         }
         
         IPlayerProgression progression = player.getCapability(ManaAndArtificeMod.getProgressionCapability()).orElse(null);
         if (progression == null) {
+            LOGGER.error("ProgressCommand: Failed to get progression capability for player {} during completion", player.getName().getString());
             source.sendFailure(Component.literal("Failed to get progression capability for " + player.getName().getString()));
             return;
         }

--- a/src/main/java/org/sosly/witchcraft/compat/MysticAlchemyCompat.java
+++ b/src/main/java/org/sosly/witchcraft/compat/MysticAlchemyCompat.java
@@ -1,5 +1,6 @@
 package org.sosly.witchcraft.compat;
 
+import com.mojang.logging.LogUtils;
 import com.mysticalchemy.crucible.CrucibleTile;
 import com.mysticalchemy.init.BlockInit;
 import com.mysticalchemy.init.RecipeInit;
@@ -13,6 +14,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import org.slf4j.Logger;
 
 import java.util.List;
 import java.util.Map;
@@ -26,8 +28,17 @@ import static org.sosly.witchcraft.items.alchemy.WitchEyeItem.createDummyCraftin
  * preventing early class loading issues.
  */
 public class MysticAlchemyCompat {
+    private static final Logger LOGGER = LogUtils.getLogger();
     
     public static void revealAlchemicalProperties(Level level, ItemStack item, List<Component> tooltips) {
+        try {
+            doRevealAlchemicalProperties(level, item, tooltips);
+        } catch (Exception e) {
+            LOGGER.error("Failed to reveal alchemical properties for item {}", item.getItem().getName(item), e);
+        }
+    }
+    
+    private static void doRevealAlchemicalProperties(Level level, ItemStack item, List<Component> tooltips) {
         var recipes = level.getRecipeManager();
         Optional<PotionIngredientRecipe> recipe = recipes.getRecipeFor(
             RecipeInit.POTION_RECIPE_TYPE.get(), 

--- a/src/main/java/org/sosly/witchcraft/entities/ai/Hover.java
+++ b/src/main/java/org/sosly/witchcraft/entities/ai/Hover.java
@@ -1,11 +1,14 @@
 package org.sosly.witchcraft.entities.ai;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.world.entity.ai.goal.Goal;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.entities.tools.FlyingBroom;
 
 import java.util.EnumSet;
 
 public class Hover extends AbstractFlyingGoal {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private static final double HOVER_RANGE = 4.0;
     private static final double PREFERRED_HOVER_HEIGHT = 1.25;
     private static final double MOVE_TO_HOVER_SPEED = 0.3;
@@ -42,8 +45,13 @@ public class Hover extends AbstractFlyingGoal {
         }
 
         double groundLevel = raycastToGround();
-        double distanceToGround = broom.getY() - groundLevel;
+        if (groundLevel < broom.level().getMinBuildHeight() - 50) {
+            LOGGER.warn("Hover raycast returned suspicious ground level {} for broom at {}", 
+                groundLevel, broom.position());
+            return false;
+        }
         
+        double distanceToGround = broom.getY() - groundLevel;
         return distanceToGround <= HOVER_RANGE;
     }
     
@@ -55,7 +63,18 @@ public class Hover extends AbstractFlyingGoal {
     @Override
     public void start() {
         double groundLevel = raycastToGround();
+        if (groundLevel < broom.level().getMinBuildHeight() - 50) {
+            LOGGER.error("Hover start failed - invalid ground level {} at {}", groundLevel, broom.position());
+            return;
+        }
+        
         targetHoverHeight = groundLevel + PREFERRED_HOVER_HEIGHT;
+        if (targetHoverHeight > broom.level().getMaxBuildHeight()) {
+            LOGGER.warn("Hover height {} exceeds world limit, clamping to {}", 
+                targetHoverHeight, broom.level().getMaxBuildHeight() - 1);
+            targetHoverHeight = broom.level().getMaxBuildHeight() - 1;
+        }
+        
         isTransitioning = true;
         baseYaw = broom.getYRot();
         basePitch = broom.getXRot();

--- a/src/main/java/org/sosly/witchcraft/entities/ai/ReturnToOwner.java
+++ b/src/main/java/org/sosly/witchcraft/entities/ai/ReturnToOwner.java
@@ -1,13 +1,16 @@
 package org.sosly.witchcraft.entities.ai;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.phys.Vec3;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.entities.tools.FlyingBroom;
 
 import java.util.EnumSet;
 
 public class ReturnToOwner extends Goal {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private static final double TARGET_REACH_DISTANCE = 4.0;
     private static final double CLOSE_DISTANCE_THRESHOLD = 1.5;
     private static final double MAX_SECONDS_TO_TARGET = 5;
@@ -65,7 +68,10 @@ public class ReturnToOwner extends Goal {
             return;
         }
 
-        broom.getNavigation().moveTo(summonTarget.x, summonTarget.y, summonTarget.z, speedModifier);
+        boolean pathSuccess = broom.getNavigation().moveTo(summonTarget.x, summonTarget.y, summonTarget.z, speedModifier);
+        if (!pathSuccess) {
+            LOGGER.warn("Failed to create path to summon target at ({}, {}, {})", summonTarget.x, summonTarget.y, summonTarget.z);
+        }
     }
     
     private boolean hasReachedTarget(Vec3 target) {

--- a/src/main/java/org/sosly/witchcraft/entities/ai/SafelyDescend.java
+++ b/src/main/java/org/sosly/witchcraft/entities/ai/SafelyDescend.java
@@ -1,12 +1,15 @@
 package org.sosly.witchcraft.entities.ai;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.world.entity.ai.attributes.Attributes;
+import org.slf4j.Logger;
 import net.minecraft.world.entity.ai.goal.Goal;
 import org.sosly.witchcraft.entities.tools.FlyingBroom;
 
 import java.util.EnumSet;
 
 public class SafelyDescend extends AbstractFlyingGoal {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private static final float MAX_HOVER_HEIGHT = 5.0f;
     private static final float MIN_HOVER_HEIGHT = 1.0f;
     private static final float HOVER_TARGET_HEIGHT = 1.25f;
@@ -64,19 +67,36 @@ public class SafelyDescend extends AbstractFlyingGoal {
     @Override
     public void start() {
         double groundLevel = raycastToGround();
+        if (groundLevel < broom.level().getMinBuildHeight() - 50) {
+            LOGGER.warn("Raycast to ground returned extremely low value {} for broom at {}, may indicate raycast failure", 
+                groundLevel, broom.position());
+        }
+        
         targetY = (float) (groundLevel + HOVER_TARGET_HEIGHT);
         
         int minBuildHeight = broom.level().getMinBuildHeight();
         int maxBuildHeight = broom.level().getMaxBuildHeight();
         
+        float originalTargetY = targetY;
         targetY = Math.max(targetY, minBuildHeight + 1);
         targetY = Math.min(targetY, maxBuildHeight - 1);
+        
+        if (Math.abs(originalTargetY - targetY) > 5) {
+            LOGGER.warn("SafelyDescend target height clamped from {} to {} due to world bounds at {}", 
+                originalTargetY, targetY, broom.position());
+        }
     }
 
     @Override
     public void tick() {
         double currentY = broom.getY();
         double speed = broom.getAttributeValue(Attributes.FLYING_SPEED);
+        
+        if (speed <= 0) {
+            LOGGER.error("Broom at {} has invalid flying speed: {}", broom.position(), speed);
+            return;
+        }
+        
         double baseMoveDistance = speed / TICKS_PER_SECOND * BASE_SPEED_MULTIPLIER;
         
         double distanceToTarget = Math.abs(targetY - currentY);

--- a/src/main/java/org/sosly/witchcraft/entities/controls/FlightController.java
+++ b/src/main/java/org/sosly/witchcraft/entities/controls/FlightController.java
@@ -1,6 +1,8 @@
 package org.sosly.witchcraft.entities.controls;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.client.Minecraft;
+import org.slf4j.Logger;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.MoverType;
@@ -8,6 +10,7 @@ import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.phys.Vec3;
 
 public class FlightController {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private Vec3 currentMotion = Vec3.ZERO;
     private double currentVerticalMotion = 0.0;
     private Boolean originalSprintToggle = null;
@@ -64,6 +67,9 @@ public class FlightController {
         if (controllingPassenger instanceof LocalPlayer localPlayer) {
             return calculateLocalPlayerVerticalMotion(localPlayer, speed);
         }
+        if (controllingPassenger != null) {
+            LOGGER.debug("Non-LocalPlayer controlling passenger type: {}", controllingPassenger.getClass().getSimpleName());
+        }
         return 0;
     }
 
@@ -99,6 +105,13 @@ public class FlightController {
     public void handlePlayerControlledTravel(PathfinderMob entity, Vec3 travelVector, double speed) {
         LivingEntity controllingPassenger = entity.getControllingPassenger();
         if (controllingPassenger == null) {
+            LOGGER.warn("FlightController handlePlayerControlledTravel called with null controlling passenger for entity at {}", 
+                entity.position());
+            return;
+        }
+        
+        if (speed <= 0) {
+            LOGGER.error("FlightController received invalid speed {} for entity at {}", speed, entity.position());
             return;
         }
         

--- a/src/main/java/org/sosly/witchcraft/entities/tools/FlyingBroom.java
+++ b/src/main/java/org/sosly/witchcraft/entities/tools/FlyingBroom.java
@@ -1,5 +1,6 @@
 package org.sosly.witchcraft.entities.tools;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.Packet;
@@ -26,6 +27,7 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.api.capabilities.IBroomCapability;
 import org.sosly.witchcraft.capabilities.broom.BroomProvider;
 import org.sosly.witchcraft.config.ServerConfig;
@@ -43,6 +45,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 public class FlyingBroom extends PathfinderMob {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private static final EntityDataAccessor<Float> DATA_HOVER_OFFSET = SynchedEntityData.defineId(FlyingBroom.class, EntityDataSerializers.FLOAT);
     private static final EntityDataAccessor<Integer> DATA_RIBBON_COLOR = SynchedEntityData.defineId(FlyingBroom.class, EntityDataSerializers.INT);
     private static final EntityDataAccessor<String> DATA_HANDLE_WOOD = SynchedEntityData.defineId(FlyingBroom.class, EntityDataSerializers.STRING);
@@ -64,14 +67,13 @@ public class FlyingBroom extends PathfinderMob {
         Objects.requireNonNull(this.getAttribute(Attributes.FLYING_SPEED)).setBaseValue(ServerConfig.flyingBroomSpeed);
     }
 
+
     private void cacheBroomLocation(Player player) {
-        LazyOptional<IBroomCapability> cap = player.getCapability(BroomProvider.BROOM);
-        cap.ifPresent(broom -> {
-            if (this.uuid.equals(broom.getBondedBroomId())) {
-                broom.setLastKnownPosition(this.blockPosition());
-                broom.setLastKnownDimension(this.level().dimension().location());
-            }
-        });
+        IBroomCapability broom = BroomProvider.getBroomCapability(player, this.uuid);
+        if (broom != null) {
+            broom.setLastKnownPosition(this.blockPosition());
+            broom.setLastKnownDimension(this.level().dimension().location());
+        }
     }
 
     @Override
@@ -90,12 +92,10 @@ public class FlyingBroom extends PathfinderMob {
     }
 
     public void clearPlayerBond(Player player) {
-        LazyOptional<IBroomCapability> cap = player.getCapability(BroomProvider.BROOM);
-        cap.ifPresent(broom -> {
-            if (this.uuid.equals(broom.getBondedBroomId())) {
-                broom.reset();
-            }
-        });
+        IBroomCapability broom = BroomProvider.getBroomCapability(player, this.uuid);
+        if (broom != null) {
+            broom.reset();
+        }
     }
 
 
@@ -302,6 +302,7 @@ public class FlyingBroom extends PathfinderMob {
         if (compound.contains("BroomData")) {
             this.broomData = FlyingBroomData.fromNBT(compound.getCompound("BroomData"));
         } else {
+            LOGGER.warn("NBT missing BroomData, creating default");
             this.broomData = new FlyingBroomData();
         }
 

--- a/src/main/java/org/sosly/witchcraft/events/CauldronInteractions.java
+++ b/src/main/java/org/sosly/witchcraft/events/CauldronInteractions.java
@@ -30,11 +30,7 @@ public class CauldronInteractions {
     @SubscribeEvent
     public static void setup(FMLCommonSetupEvent event) {
         event.enqueueWork(() -> {
-            try {
-                registerCondensedMoonlightInteractions();
-            } catch (Exception e) {
-                LOGGER.error("Failed to register cauldron interactions", e);
-            }
+            registerCondensedMoonlightInteractions();
         });
     }
     

--- a/src/main/java/org/sosly/witchcraft/events/CauldronInteractions.java
+++ b/src/main/java/org/sosly/witchcraft/events/CauldronInteractions.java
@@ -16,6 +16,8 @@ import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import com.mojang.logging.LogUtils;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.items.ItemRegistry;
 import org.sosly.witchcraft.blocks.BlockRegistry;
@@ -23,11 +25,16 @@ import org.sosly.witchcraft.blocks.alchemy.CondensedMoonlightCauldronBlock;
 
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class CauldronInteractions {
+    private static final Logger LOGGER = LogUtils.getLogger();
     
     @SubscribeEvent
     public static void setup(FMLCommonSetupEvent event) {
         event.enqueueWork(() -> {
-            registerCondensedMoonlightInteractions();
+            try {
+                registerCondensedMoonlightInteractions();
+            } catch (Exception e) {
+                LOGGER.error("Failed to register cauldron interactions", e);
+            }
         });
     }
     

--- a/src/main/java/org/sosly/witchcraft/events/Factions.java
+++ b/src/main/java/org/sosly/witchcraft/events/Factions.java
@@ -10,8 +10,8 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import com.mojang.logging.LogUtils;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.api.capabilities.IBroomCapability;
 import org.sosly.witchcraft.api.capabilities.ICovenCapability;
@@ -25,7 +25,7 @@ import org.sosly.witchcraft.utils.TierEffectManager;
 
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class Factions {
-    private static final Logger LOGGER = LogManager.getLogger(Factions.class);
+    private static final Logger LOGGER = LogUtils.getLogger();
     
     @SubscribeEvent
     public static void onAttachCapability(AttachCapabilitiesEvent<?> event) {
@@ -79,6 +79,8 @@ public class Factions {
         IPlayerProgression progression = player.getCapability(PlayerProgressionProvider.PROGRESSION)
                 .orElse(null);
         if (progression == null) {
+            LOGGER.warn("Player {} missing progression capability when generating tier requirements", 
+                player.getName().getString());
             return;
         }
         
@@ -90,6 +92,8 @@ public class Factions {
         ICovenCapability covenCap = player.getCapability(CovenProvider.COVEN)
                 .orElse(null);
         if (covenCap == null) {
+            LOGGER.error("Player {} missing coven capability when generating tier requirements", 
+                player.getName().getString());
             return;
         }
         

--- a/src/main/java/org/sosly/witchcraft/events/enchantments/Dedication.java
+++ b/src/main/java/org/sosly/witchcraft/events/enchantments/Dedication.java
@@ -1,6 +1,6 @@
 package org.sosly.witchcraft.events.enchantments;
 
-
+import com.mojang.logging.LogUtils;
 import com.mna.api.events.RuneforgeEnchantEvent;
 import com.mna.effects.EffectInit;
 import com.mna.items.sorcery.MagicStaff;
@@ -15,6 +15,7 @@ import net.minecraftforge.event.GrindstoneEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.compat.MysticAlchemyCompat;
 import org.sosly.witchcraft.enchantments.EnchantmentRegistry;
@@ -25,6 +26,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class Dedication {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    
     @SubscribeEvent
     public static void onClick(PlayerInteractEvent event) {
         Level level = event.getLevel();

--- a/src/main/java/org/sosly/witchcraft/events/entities/RitualWitchHandler.java
+++ b/src/main/java/org/sosly/witchcraft/events/entities/RitualWitchHandler.java
@@ -1,15 +1,18 @@
 package org.sosly.witchcraft.events.entities;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.monster.Witch;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.Witchcraft;
 
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class RitualWitchHandler {
+    private static final Logger LOGGER = LogUtils.getLogger();
     
     @SubscribeEvent
     public static void onWitchTick(LivingEvent.LivingTickEvent event) {

--- a/src/main/java/org/sosly/witchcraft/events/entities/WitchGossip.java
+++ b/src/main/java/org/sosly/witchcraft/events/entities/WitchGossip.java
@@ -1,5 +1,6 @@
 package org.sosly.witchcraft.events.entities;
 
+import com.mojang.logging.LogUtils;
 import com.mna.api.capabilities.IPlayerProgression;
 import com.mna.api.faction.IFaction;
 import com.mna.capabilities.playerdata.progression.PlayerProgressionProvider;
@@ -12,6 +13,7 @@ import net.minecraft.world.phys.AABB;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.config.ServerConfig;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.effects.EffectRegistry;
@@ -23,6 +25,7 @@ import java.util.List;
 
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class WitchGossip {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private static final String LAST_GOSSIP_TIME_KEY = "mnaw:last_gossip_time";
 
     @SubscribeEvent
@@ -86,6 +89,7 @@ public class WitchGossip {
     private static boolean isValidGossipTrigger(Player player) {
         IPlayerProgression progression = player.getCapability(PlayerProgressionProvider.PROGRESSION).orElse(null);
         if (progression == null) {
+            LOGGER.warn("Player {} missing progression capability during gossip validation", player.getName().getString());
             return true;
         }
         

--- a/src/main/java/org/sosly/witchcraft/events/items/BloodyNeedle.java
+++ b/src/main/java/org/sosly/witchcraft/events/items/BloodyNeedle.java
@@ -1,6 +1,7 @@
 package org.sosly.witchcraft.events.items;
 
 import com.mna.items.ItemInit;
+import com.mojang.logging.LogUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -20,6 +21,7 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.items.ItemRegistry;
 import org.sosly.witchcraft.items.sympathy.BoundPoppetItem;
@@ -29,7 +31,7 @@ import java.util.UUID;
 
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class BloodyNeedle {
-
+    private static final Logger LOGGER = LogUtils.getLogger();
 
     @SubscribeEvent
     public static void onCraftWithPoppet(PlayerEvent.ItemCraftedEvent event) {
@@ -49,17 +51,20 @@ public class BloodyNeedle {
         }
 
         if (needle.isEmpty()) {
+            LOGGER.warn("Player {} attempted to craft bound poppet without bloody needle", event.getEntity().getName().getString());
             event.setCanceled(true);
             return;
         }
 
         CompoundTag tag = needle.getTag();
         if (tag == null) {
+            LOGGER.error("Bloody needle missing NBT data for player {}", event.getEntity().getName().getString());
             event.setResult(Event.Result.DENY);
             event.setCanceled(true);
             return;
         }
         if (!SympathyHelper.isBound(needle)) {
+            LOGGER.warn("Player {} attempted to use unbound bloody needle", event.getEntity().getName().getString());
             event.setResult(Event.Result.DENY);
             event.setCanceled(true);
             return;

--- a/src/main/java/org/sosly/witchcraft/events/items/MoonthreadArmor.java
+++ b/src/main/java/org/sosly/witchcraft/events/items/MoonthreadArmor.java
@@ -18,6 +18,8 @@ import net.minecraftforge.event.entity.living.MobEffectEvent;
 import net.minecraftforge.event.entity.living.MobSpawnEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import com.mojang.logging.LogUtils;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.config.ServerConfig;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.api.capabilities.IMoonthreadArmorData;
@@ -31,6 +33,7 @@ import java.util.Random;
 
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID)
 public class MoonthreadArmor {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private static final Random random = new Random();
     private static final long TEMPORARY_IMMUNITY_DURATION = 200L;
     
@@ -103,6 +106,7 @@ public class MoonthreadArmor {
         
         IMoonthreadArmorData armorData = player.getCapability(MoonthreadArmorProvider.MOONTHREAD_ARMOR_DATA).orElse(null);
         if (armorData == null) {
+            LOGGER.error("Failed to retrieve moonthread armor capability for player {}", player.getName().getString());
             return false;
         }
         
@@ -152,8 +156,6 @@ public class MoonthreadArmor {
         MobEffectInstance effectInstance = event.getEffectInstance();
         if (shouldBlockHarmfulEffect(player, effectInstance)) {
             player.removeEffect(effectInstance.getEffect());
-            Witchcraft.LOGGER.debug("Moonthread Armor removed harmful effect {} from player {}", 
-                effectInstance.getEffect().getDescriptionId(), player.getName().getString());
         }
     }
     
@@ -196,7 +198,7 @@ public class MoonthreadArmor {
             }
             
             event.setSpawnCancelled(true);
-            Witchcraft.LOGGER.info("Moonthread Armor prevented {} from spawning at ({}, {}, {}) near player {}", 
+            LOGGER.info("Moonthread Armor prevented {} from spawning at ({}, {}, {}) near player {}", 
                 event.getEntity().getType().getDescription(),
                 spawnX, spawnY, spawnZ,
                 player.getName().getString());

--- a/src/main/java/org/sosly/witchcraft/events/items/PotionAmulet.java
+++ b/src/main/java/org/sosly/witchcraft/events/items/PotionAmulet.java
@@ -11,6 +11,8 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.registries.ForgeRegistries;
+import com.mojang.logging.LogUtils;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.items.alchemy.PotionAmuletItem;
 
@@ -19,6 +21,7 @@ import java.util.Optional;
 
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class PotionAmulet {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private static final ResourceLocation potionLocation = new ResourceLocation("minecraft:potion");
 
     @SubscribeEvent
@@ -37,12 +40,15 @@ public class PotionAmulet {
         }
 
         if (potionStack.isEmpty()) {
+            LOGGER.warn("No potion found in crafting recipe for potion amulet by player {}", event.getEntity().getName().getString());
             PotionAmuletItem.clean(crafting);
             return;
         }
 
         List<MobEffectInstance> effects = PotionUtils.getMobEffects(potionStack);
         if (effects.isEmpty()) {
+            LOGGER.warn("Potion {} has no effects for amulet crafting by player {}", 
+                ForgeRegistries.ITEMS.getKey(potionStack.getItem()), event.getEntity().getName().getString());
             return;
         }
 

--- a/src/main/java/org/sosly/witchcraft/events/items/PotionPouch.java
+++ b/src/main/java/org/sosly/witchcraft/events/items/PotionPouch.java
@@ -14,6 +14,8 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import com.mojang.logging.LogUtils;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.items.ItemRegistry;
 import org.sosly.witchcraft.items.alchemy.PotionPouchItem;
@@ -22,6 +24,7 @@ import java.util.List;
 
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class PotionPouch {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private static List<PractitionersPatch> allowedPatches = List.of();
 
     @SubscribeEvent
@@ -65,6 +68,8 @@ public class PotionPouch {
 
         BlockEntity blockEntity = level.getBlockEntity(pos);
         if (!(blockEntity instanceof RunicAnvilTile)) {
+            LOGGER.error("Expected RunicAnvilTile but found {} at {} for potion pouch interaction", 
+                blockEntity != null ? blockEntity.getClass().getSimpleName() : "null", pos);
             return;
         }
 
@@ -76,6 +81,8 @@ public class PotionPouch {
 
         ItemStack material = runicAnvilTile.getItem(1);
         if (!((PotionPouchItem)baseItem.getItem()).addPatchToPouch(baseItem, material)) {
+            LOGGER.warn("Failed to add patch {} to potion pouch for player {}", 
+                material.getDisplayName().getString(), event.getEntity().getName().getString());
             return;
         }
 

--- a/src/main/java/org/sosly/witchcraft/events/items/ScentDetection.java
+++ b/src/main/java/org/sosly/witchcraft/events/items/ScentDetection.java
@@ -1,16 +1,19 @@
 package org.sosly.witchcraft.events.items;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.effects.EffectRegistry;
 import org.sosly.witchcraft.utils.ScentedItemHelper;
 
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class ScentDetection {
+    private static final Logger LOGGER = LogUtils.getLogger();
     
     @SubscribeEvent
     public static void onPlayerTick(TickEvent.PlayerTickEvent event) {

--- a/src/main/java/org/sosly/witchcraft/events/items/VinteumNeedle.java
+++ b/src/main/java/org/sosly/witchcraft/events/items/VinteumNeedle.java
@@ -1,5 +1,6 @@
 package org.sosly.witchcraft.events.items;
 
+import com.mojang.logging.LogUtils;
 import com.mna.items.ItemInit;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.Entity;
@@ -10,6 +11,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.config.ServerConfig;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.items.ItemRegistry;
@@ -17,6 +19,8 @@ import org.sosly.witchcraft.utils.SympathyHelper;
 
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class VinteumNeedle {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    
     @SubscribeEvent
     public static void onAttackEntity(AttackEntityEvent event) {
         LivingEntity attacker = event.getEntity();
@@ -30,6 +34,11 @@ public class VinteumNeedle {
         }
 
         Entity target = event.getTarget();
+        if (target == null) {
+            LOGGER.warn("Attack event has null target");
+            return;
+        }
+        
         if (!(target instanceof Player || target instanceof Mob)) {
             return;
         }
@@ -44,6 +53,7 @@ public class VinteumNeedle {
         if (tag == null) {
             tag = new CompoundTag();
         }
+        
         tag.putUUID("target", target.getUUID());
         tag.putString("type", target.getType().getDescription().getString());
 

--- a/src/main/java/org/sosly/witchcraft/events/items/WitchEye.java
+++ b/src/main/java/org/sosly/witchcraft/events/items/WitchEye.java
@@ -1,14 +1,18 @@
 package org.sosly.witchcraft.events.items;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.items.alchemy.WitchEyeItem;
 
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class WitchEye {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    
     @SubscribeEvent
     public static void onTooltip(ItemTooltipEvent event) {
         Player player = event.getEntity();

--- a/src/main/java/org/sosly/witchcraft/events/rituals/Sympathy.java
+++ b/src/main/java/org/sosly/witchcraft/events/rituals/Sympathy.java
@@ -13,8 +13,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import com.mojang.logging.LogUtils;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.Witchcraft;
 import org.sosly.witchcraft.api.capabilities.ICovenCapability;
 import org.sosly.witchcraft.capabilities.coven.CovenProvider;
@@ -29,7 +29,7 @@ import java.util.List;
  */
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class Sympathy {
-    private static final Logger LOGGER = LogManager.getLogger(Sympathy.class);
+    private static final Logger LOGGER = LogUtils.getLogger();
     
     @SubscribeEvent
     public static void SympathyProgression(RitualCompleteEvent event) {
@@ -44,36 +44,51 @@ public class Sympathy {
         
         ICovenCapability covenCap = caster.getCapability(CovenProvider.COVEN).orElse(null);
         if (covenCap == null) {
+            LOGGER.error("Failed to retrieve coven capability for player {}", caster.getName().getString());
             return;
         }
         
         ItemStack boundPoppet = findBoundPoppet(event.getCollectedReagents());
         if (boundPoppet.isEmpty()) {
+            LOGGER.warn("No bound poppet found in sympathy ritual reagents for player {}", caster.getName().getString());
             return;
         }
         
         ServerLevel level = (ServerLevel) caster.level();
         Entity target = SympathyHelper.getBoundEntity(boundPoppet, level);
+        
+        if (target == null) {
+            LOGGER.warn("Bound poppet target entity not found for player {}", caster.getName().getString());
+            return;
+        }
+        
         if (!(target instanceof Witch)) {
+            LOGGER.warn("Bound poppet target is not a witch ({}), cannot progress coven tier for player {}", 
+                target.getClass().getSimpleName(), caster.getName().getString());
             return;
         }
         
         ISpellDefinition spell = getSpellFromReagents(event.getCollectedReagents(), caster);
         if (spell == null) {
+            LOGGER.warn("No valid spell found in sympathy ritual reagents for player {}", caster.getName().getString());
             return;
         }
         
         IPlayerProgression progression = caster.getCapability(PlayerProgressionProvider.PROGRESSION).orElse(null);
         if (progression == null) {
+            LOGGER.error("Failed to retrieve player progression capability for player {}", caster.getName().getString());
             return;
         }
         
         int nextTier = progression.getTier() + 1;
         if (nextTier < 3 || nextTier > 5) {
+            LOGGER.warn("Player {} tier progression {} is outside valid coven range (3-5)", 
+                caster.getName().getString(), nextTier);
             return;
         }
         
         if (covenCap.getTierEffectsRequired(nextTier) == null) {
+            LOGGER.warn("No tier effects defined for tier {} for player {}", nextTier, caster.getName().getString());
             return;
         }
         

--- a/src/main/java/org/sosly/witchcraft/guis/containers/PotionPouchContainer.java
+++ b/src/main/java/org/sosly/witchcraft/guis/containers/PotionPouchContainer.java
@@ -1,17 +1,21 @@
 package org.sosly.witchcraft.guis.containers;
 
 import com.mna.gui.containers.slots.SlotNoPickup;
+import com.mojang.logging.LogUtils;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.items.SlotItemHandler;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
 import org.sosly.witchcraft.guis.ContainerRegistry;
 import org.sosly.witchcraft.guis.slots.PotionSlot;
 import org.sosly.witchcraft.inventories.PotionPouchInventory;
 
 public class PotionPouchContainer extends AbstractPlayerInventoryContainer {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    
     private PotionPouchInventory inventory;
     private final boolean isClientside;
 

--- a/src/main/java/org/sosly/witchcraft/items/alchemy/PotionAmuletItem.java
+++ b/src/main/java/org/sosly/witchcraft/items/alchemy/PotionAmuletItem.java
@@ -1,6 +1,8 @@
 package org.sosly.witchcraft.items.alchemy;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.ChatFormatting;
+import org.slf4j.Logger;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -21,6 +23,8 @@ import java.util.Map;
 import java.util.Optional;
 
 public class PotionAmuletItem extends Item implements ICurioItem {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    
     public PotionAmuletItem() {
         super(new Properties().stacksTo(1));
     }
@@ -28,6 +32,7 @@ public class PotionAmuletItem extends Item implements ICurioItem {
     public static Optional<ItemStack> getStack(Player player) {
         Optional<ICuriosItemHandler> curios = CuriosApi.getCuriosInventory(player).resolve();
         if (curios.isEmpty()) {
+            LOGGER.warn("Could not access Curios inventory for player {}", player.getName().getString());
             return Optional.empty();
         }
 
@@ -46,6 +51,10 @@ public class PotionAmuletItem extends Item implements ICurioItem {
         for (int i = 0; i < count; i++) {
             CompoundTag effectTag = tag.getCompound("immunity" + i);
             MobEffectInstance instance = MobEffectInstance.load(effectTag);
+            if (instance == null) {
+                LOGGER.error("Failed to load MobEffectInstance from NBT tag immunity{} in potion amulet", i);
+                continue;
+            }
             effects.add(instance);
         }
 
@@ -62,6 +71,10 @@ public class PotionAmuletItem extends Item implements ICurioItem {
         for (int i = 0; i < count; i++) {
             CompoundTag effectTag = tag.getCompound("immunity" + i);
             MobEffectInstance instance = MobEffectInstance.load(effectTag);
+            if (instance == null) {
+                LOGGER.error("Failed to load MobEffectInstance from NBT tag immunity{} during immunity check", i);
+                continue;
+            }
             if (instance.getEffect() == effect.getEffect()) {
                 return true;
             }

--- a/src/main/java/org/sosly/witchcraft/items/alchemy/PotionPouchItem.java
+++ b/src/main/java/org/sosly/witchcraft/items/alchemy/PotionPouchItem.java
@@ -1,6 +1,8 @@
 package org.sosly.witchcraft.items.alchemy;
 
+import com.mojang.logging.LogUtils;
 import com.mna.KeybindInit;
+import org.slf4j.Logger;
 import com.mna.api.items.ITieredItem;
 import com.mna.items.base.IRadialInventorySelect;
 import com.mna.items.base.ItemBagBase;
@@ -37,6 +39,7 @@ import java.util.List;
 import java.util.UUID;
 
 public class PotionPouchItem extends ItemBagBase implements IRadialInventorySelect, ITieredItem<PotionPouchItem> {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private int tier;
 
     public PotionPouchItem() {
@@ -130,8 +133,15 @@ public class PotionPouchItem extends ItemBagBase implements IRadialInventorySele
 
     @Override
     public int capacity(@Nullable Player player) {
+        if (player == null) {
+            LOGGER.warn("PotionPouchItem capacity called with null player");
+            return 0;
+        }
+        
         ItemStack stack = player.getItemInHand(InteractionHand.MAIN_HAND);
         if (!(stack.getItem() instanceof PotionPouchItem)) {
+            LOGGER.warn("Player {} main hand item is not PotionPouchItem: {}", 
+                player.getName().getString(), stack.getItem().getClass().getSimpleName());
             return 0;
         }
         
@@ -160,8 +170,16 @@ public class PotionPouchItem extends ItemBagBase implements IRadialInventorySele
         }
         
         UUID targetUUID = pouch.getOrCreateTag().getUUID("conveyance_target");
+        if (targetUUID == null) {
+            LOGGER.error("PotionPouch has conveyance enabled but no valid target UUID");
+            potionStack.finishUsingItem(level, target);
+            getInventory(pouch).setStackInSlot(getIndex(pouch), potionStack);
+            return pouch;
+        }
+        
         Player playerTarget = level.getPlayerByUUID(targetUUID);
         if (playerTarget == null) {
+            LOGGER.warn("PotionPouch conveyance target player with UUID {} not found - may be offline", targetUUID);
             potionStack.finishUsingItem(level, target);
             getInventory(pouch).setStackInSlot(getIndex(pouch), potionStack);
             return pouch;

--- a/src/main/java/org/sosly/witchcraft/items/alchemy/WitchEyeItem.java
+++ b/src/main/java/org/sosly/witchcraft/items/alchemy/WitchEyeItem.java
@@ -45,11 +45,7 @@ public class WitchEyeItem extends Item {
             return;
         }
 
-        try {
-            MysticAlchemyCompat.revealAlchemicalProperties(level, item, tooltips);
-        } catch (Exception e) {
-            LOGGER.error("Failed to reveal alchemical properties for item {}", item.getItem().getName(item), e);
-        }
+        MysticAlchemyCompat.revealAlchemicalProperties(level, item, tooltips);
     }
 
     public static CraftingContainer createDummyCraftingInventory(ItemStack stack) {

--- a/src/main/java/org/sosly/witchcraft/items/alchemy/WitchEyeItem.java
+++ b/src/main/java/org/sosly/witchcraft/items/alchemy/WitchEyeItem.java
@@ -1,6 +1,8 @@
 package org.sosly.witchcraft.items.alchemy;
 
+import com.mojang.logging.LogUtils;
 import net.minecraft.network.chat.Component;
+import org.slf4j.Logger;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.CraftingContainer;
@@ -21,6 +23,8 @@ import java.util.List;
 import java.util.Optional;
 
 public class WitchEyeItem extends Item {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    
     public WitchEyeItem() {
         super(new Item.Properties().stacksTo(1).rarity(Rarity.RARE));
     }
@@ -28,6 +32,7 @@ public class WitchEyeItem extends Item {
     public static boolean hasWitchEye(Player player) {
         Optional<ICuriosItemHandler> curios = CuriosApi.getCuriosInventory(player).resolve();
         if (curios.isEmpty()) {
+            LOGGER.warn("Could not access Curios inventory for player {} when checking for witch eye", player.getName().getString());
             return false;
         }
 
@@ -40,7 +45,11 @@ public class WitchEyeItem extends Item {
             return;
         }
 
-        MysticAlchemyCompat.revealAlchemicalProperties(level, item, tooltips);
+        try {
+            MysticAlchemyCompat.revealAlchemicalProperties(level, item, tooltips);
+        } catch (Exception e) {
+            LOGGER.error("Failed to reveal alchemical properties for item {}", item.getItem().getName(item), e);
+        }
     }
 
     public static CraftingContainer createDummyCraftingInventory(ItemStack stack) {

--- a/src/main/java/org/sosly/witchcraft/items/armor/MoonthreadArmorItem.java
+++ b/src/main/java/org/sosly/witchcraft/items/armor/MoonthreadArmorItem.java
@@ -1,6 +1,8 @@
 package org.sosly.witchcraft.items.armor;
 
+import com.mojang.logging.LogUtils;
 import com.mna.api.capabilities.IPlayerMagic;
+import org.slf4j.Logger;
 import com.mna.api.faction.IFaction;
 import com.mna.api.items.IFactionSpecific;
 import com.mna.api.items.ITieredItem;
@@ -39,6 +41,7 @@ import java.util.Random;
 import java.util.function.Consumer;
 
 public class MoonthreadArmorItem extends ArmorItem implements GeoItem, ISetItem, ITieredItem<MoonthreadArmorItem>, IFactionSpecific, IBrokenArmorReplaceable<MoonthreadArmorItem>, IManaRepairable {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private int tier = -1;
     private static final ResourceLocation MOONTHREAD_SET_BONUS = new ResourceLocation(Witchcraft.MOD_ID, "moonthread_armor_set_bonus");
     private AnimatableInstanceCache animCache = GeckoLibUtil.createInstanceCache(this);
@@ -137,7 +140,13 @@ public class MoonthreadArmorItem extends ArmorItem implements GeoItem, ISetItem,
         }
         
         IPlayerMagic magic = player.getCapability(PlayerMagicProvider.MAGIC).orElse(null);
-        if (magic == null || magic.getCastingResource() == null) {
+        if (magic == null) {
+            LOGGER.warn("Could not access player magic capability for {} during moonthread armor tick", player.getName().getString());
+            return;
+        }
+        
+        if (magic.getCastingResource() == null) {
+            LOGGER.warn("Player {} has null casting resource during moonthread armor tick", player.getName().getString());
             return;
         }
         
@@ -150,6 +159,11 @@ public class MoonthreadArmorItem extends ArmorItem implements GeoItem, ISetItem,
         if (level.getGameTime() % 20 == 0) {
             float percentPerSecond = 1.0f / ServerConfig.moonthreadArmorEarthenRegenTime;
             float regenAmount = maxAmount * percentPerSecond;
+            
+            if (regenAmount <= 0) {
+                LOGGER.warn("Invalid regen amount {} calculated for player {}", regenAmount, player.getName().getString());
+                return;
+            }
             
             magic.getCastingResource().restore(regenAmount);
         }

--- a/src/main/java/org/sosly/witchcraft/items/sympathy/BoundPoppetItem.java
+++ b/src/main/java/org/sosly/witchcraft/items/sympathy/BoundPoppetItem.java
@@ -1,6 +1,8 @@
 package org.sosly.witchcraft.items.sympathy;
 
+import com.mojang.logging.LogUtils;
 import com.mna.items.ritual.PlayerCharm;
+import org.slf4j.Logger;
 import net.minecraft.ChatFormatting;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.core.BlockPos;
@@ -35,6 +37,7 @@ import java.util.List;
 import java.util.UUID;
 
 public class BoundPoppetItem extends PlayerCharm {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private final Block block;
 
     public BoundPoppetItem(Block block) {
@@ -63,15 +66,18 @@ public class BoundPoppetItem extends PlayerCharm {
         
         BlockPlaceContext blockplacecontext = this.updatePlacementContext(pContext);
         if (blockplacecontext == null) {
+            LOGGER.error("Failed to create valid block placement context for bound poppet at {}", pContext.getClickedPos());
             return InteractionResult.FAIL;
         }
         
         BlockState blockstate = this.getPlacementState(blockplacecontext);
         if (blockstate == null) {
+            LOGGER.error("Unable to determine valid block state for bound poppet placement at {}", blockplacecontext.getClickedPos());
             return InteractionResult.FAIL;
         }
         
         if (!this.placeBlock(blockplacecontext, blockstate)) {
+            LOGGER.error("Failed to place bound poppet block at {} - world.setBlock returned false", blockplacecontext.getClickedPos());
             return InteractionResult.FAIL;
         }
         
@@ -165,6 +171,7 @@ public class BoundPoppetItem extends PlayerCharm {
     public static boolean updateCustomBlockEntityTag(Level pLevel, @Nullable Player pPlayer, BlockPos pPos, ItemStack pStack) {
         MinecraftServer minecraftserver = pLevel.getServer();
         if (minecraftserver == null) {
+            LOGGER.error("Cannot update block entity data - server is null");
             return false;
         }
         
@@ -175,6 +182,7 @@ public class BoundPoppetItem extends PlayerCharm {
         
         BlockEntity blockentity = pLevel.getBlockEntity(pPos);
         if (blockentity == null) {
+            LOGGER.error("Cannot update block entity data - no block entity found at {}", pPos);
             return false;
         }
         
@@ -215,6 +223,7 @@ public class BoundPoppetItem extends PlayerCharm {
 
         Player player = level.getPlayerByUUID(target);
         if (player == null) {
+            LOGGER.warn("Could not find player with UUID {} when setting bound poppet target - target may be offline", target);
             return;
         }
 
@@ -232,7 +241,16 @@ public class BoundPoppetItem extends PlayerCharm {
         }
 
         UUID target = stack.getOrCreateTag().getUUID("target");
-        return ((ServerLevel)level).getEntity(target);
+        if (target == null) {
+            LOGGER.warn("Bound poppet item has no target UUID in NBT");
+            return null;
+        }
+        
+        Entity entity = ((ServerLevel)level).getEntity(target);
+        if (entity == null) {
+            LOGGER.warn("Could not find target entity with UUID {} - entity may have been removed", target);
+        }
+        return entity;
     }
 
     public void appendHoverText(ItemStack stack, Level level, List<Component> tooltip, TooltipFlag flag) {

--- a/src/main/java/org/sosly/witchcraft/items/tools/FlyingBroom.java
+++ b/src/main/java/org/sosly/witchcraft/items/tools/FlyingBroom.java
@@ -1,6 +1,8 @@
 package org.sosly.witchcraft.items.tools;
 
+import com.mojang.logging.LogUtils;
 import com.mna.api.items.TieredItem;
+import org.slf4j.Logger;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.commands.arguments.EntityAnchorArgument;
 import net.minecraft.network.chat.Component;
@@ -28,6 +30,8 @@ import java.util.List;
 import java.util.function.Consumer;
 
 public class FlyingBroom extends TieredItem {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    
     public FlyingBroom() {
         super((new Item.Properties()).stacksTo(1));
     }
@@ -77,10 +81,18 @@ public class FlyingBroom extends TieredItem {
         
         cleanupExistingBroom(player, level);
         org.sosly.witchcraft.entities.tools.FlyingBroom broomEntity = createAndPositionBroom(context);
+        if (broomEntity == null) {
+            LOGGER.error("Failed to create broom entity for player {}", player.getName().getString());
+            return InteractionResult.FAIL;
+        }
+        
         broomEntity.setBroomData(broomData);
         bondBroomToPlayer(player, broomEntity);
         
-        level.addFreshEntity(broomEntity);
+        if (!level.addFreshEntity(broomEntity)) {
+            LOGGER.error("Failed to spawn broom entity in world for player {}", player.getName().getString());
+            return InteractionResult.FAIL;
+        }
         consumeItem(stack, player, context);
         
         return InteractionResult.SUCCESS;
@@ -106,18 +118,17 @@ public class FlyingBroom extends TieredItem {
     }
     
     private void cleanupExistingBroom(Player player, Level level) {
-        LazyOptional<IBroomCapability> cap = player.getCapability(BroomProvider.BROOM);
-        cap.ifPresent(broom -> {
-            if (!broom.hasBondedBroom()) {
-                return;
-            }
-            
-            org.sosly.witchcraft.entities.tools.FlyingBroom existingBroom = findBondedBroom(level, player, broom);
-            if (existingBroom != null) {
-                existingBroom.discard();
-            }
-            broom.setBondedBroomId(null);
-        });
+        IBroomCapability broom = BroomProvider.getBroomCapability(player);
+        if (broom == null || !broom.hasBondedBroom()) {
+            return;
+        }
+        
+        org.sosly.witchcraft.entities.tools.FlyingBroom existingBroom = findBondedBroom(level, player, broom);
+        if (existingBroom != null) {
+            LOGGER.debug("Discarding existing broom entity {} for player {}", existingBroom.getUUID(), player.getName().getString());
+            existingBroom.discard();
+        }
+        broom.setBondedBroomId(null);
     }
     
     private org.sosly.witchcraft.entities.tools.FlyingBroom findBondedBroom(Level level, Player player, IBroomCapability broom) {
@@ -146,13 +157,16 @@ public class FlyingBroom extends TieredItem {
     
     
     private void bondBroomToPlayer(Player player, org.sosly.witchcraft.entities.tools.FlyingBroom broomEntity) {
-        LazyOptional<IBroomCapability> cap = player.getCapability(BroomProvider.BROOM);
-        cap.ifPresent(broom -> {
-            broom.setBondedBroomId(broomEntity.getUUID());
-            broom.setBroomsUnlocked(true);
-            broom.setLastKnownPosition(broomEntity.blockPosition());
-            broom.setLastKnownDimension(broomEntity.level().dimension().location());
-        });
+        IBroomCapability broom = BroomProvider.getBroomCapability(player);
+        if (broom == null) {
+            return;
+        }
+        
+        broom.setBondedBroomId(broomEntity.getUUID());
+        broom.setBroomsUnlocked(true);
+        broom.setLastKnownPosition(broomEntity.blockPosition());
+        broom.setLastKnownDimension(broomEntity.level().dimension().location());
+        LOGGER.debug("Bonded broom entity {} to player {}", broomEntity.getUUID(), player.getName().getString());
     }
     
     private void consumeItem(ItemStack stack, Player player, UseOnContext context) {

--- a/src/main/java/org/sosly/witchcraft/utils/TierEffectManager.java
+++ b/src/main/java/org/sosly/witchcraft/utils/TierEffectManager.java
@@ -45,7 +45,7 @@ public class TierEffectManager {
             case 4 -> TIER_4_REQUIREMENTS;
             case 5 -> TIER_5_REQUIREMENTS;
             default -> {
-                LOGGER.error("Invalid tier: {}", tier);
+                LOGGER.error("{}", tier);
                 yield 0;
             }
         };
@@ -58,7 +58,7 @@ public class TierEffectManager {
             requirements.add(shuffled.get(i));
         }
         
-        LOGGER.info("Generated {} requirements for tier {}: {}", requirements.size(), tier, requirements);
+        LOGGER.info("{}", requirements.size(), tier, requirements);
         return requirements;
     }
     

--- a/src/main/java/org/sosly/witchcraft/utils/TierEffectManager.java
+++ b/src/main/java/org/sosly/witchcraft/utils/TierEffectManager.java
@@ -55,6 +55,7 @@ public class TierEffectManager {
             requirements.add(shuffled.get(i));
         }
         
+        LOGGER.info("Generated {} requirements for tier {}: {}", requirements.size(), tier, requirements);
         return requirements;
     }
     

--- a/src/main/java/org/sosly/witchcraft/utils/TierEffectManager.java
+++ b/src/main/java/org/sosly/witchcraft/utils/TierEffectManager.java
@@ -44,10 +44,7 @@ public class TierEffectManager {
             case 3 -> TIER_3_REQUIREMENTS;
             case 4 -> TIER_4_REQUIREMENTS;
             case 5 -> TIER_5_REQUIREMENTS;
-            default -> {
-                LOGGER.error("{}", tier);
-                yield 0;
-            }
+            default -> 0;
         };
         
         Set<ResourceLocation> requirements = new HashSet<>();
@@ -58,7 +55,6 @@ public class TierEffectManager {
             requirements.add(shuffled.get(i));
         }
         
-        LOGGER.info("{}", requirements.size(), tier, requirements);
         return requirements;
     }
     


### PR DESCRIPTION
## Summary
- Implemented comprehensive logging throughout the MNAWitchcraft codebase
- Refactored duplicated broom capability access patterns into clean helper methods
- Fixed logging violations and removed unnecessary code complexity

## Logging Implementation
- Added strategic logging at all critical user interaction points where failures would be problematic
- Updated main class to use `LogUtils.getLogger()` for consistency with Minecraft/Forge conventions  
- Added proper error logging for capability failures, NBT validation issues, and entity operations
- Focused on ERROR/WARN levels for actual problems while avoiding noise from normal operations
- Removed unnecessary DEBUG logs that were logging routine operations

## Broom Capability Refactor
- Added overloaded `getBroomCapability()` methods to `BroomProvider` with null safety and error handling
- Simple method returns capability or null, bonded variant validates player is bonded to specific broom UUID
- Eliminated duplicated capability access boilerplate across FlyingBroom entity and item classes
- Replaced callback-based complexity with simple null-checked return values for better readability

## Bug Fixes
- Removed malformed error message in BloodyNeedle event handler
- Removed unnecessary try/catch around reliable Minecraft API calls (getUUID, getString)
- Fixed NBT validation edge cases in BoundPoppetEntity and WitchsCauldronBlockEntity

🤖 Generated with [Claude Code](https://claude.ai/code)