### PR TITLE
fix: prevent crash when crafting bound poppet with malformed bloody needle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - improved "Ritual: Sympathy" guidebook entry to explain how to obtain bloody needles for bound poppet creation
 
+### Fixed
+- fixed crash when crafting bound poppet with bloody needle lacking proper NBT data (such as from /give command)
+
 ## [1.20.1-forge-0.3.0-alpha](https://github.com/SoSly/MnAWitchcraft/releases/tag/1.20.1-forge-0.3.0-alpha)
 ### Added
 - added Flying Broom, a customizable rideable entity that allows flight in the overworld and nether

--- a/src/main/java/org/sosly/witchcraft/events/items/BloodyNeedle.java
+++ b/src/main/java/org/sosly/witchcraft/events/items/BloodyNeedle.java
@@ -69,6 +69,20 @@ public class BloodyNeedle {
             event.setCanceled(true);
             return;
         }
+        
+        if (!tag.hasUUID("target")) {
+            LOGGER.error("Bloody needle missing target UUID for player {}", event.getEntity().getName().getString());
+            event.setResult(Event.Result.DENY);
+            event.setCanceled(true);
+            return;
+        }
+        
+        if (!tag.contains("type")) {
+            LOGGER.error("Bloody needle missing type data for player {}", event.getEntity().getName().getString());
+            event.setResult(Event.Result.DENY);
+            event.setCanceled(true);
+            return;
+        }
 
         UUID target = tag.getUUID("target");
         String type = tag.getString("type");

--- a/src/main/java/org/sosly/witchcraft/utils/SympathyHelper.java
+++ b/src/main/java/org/sosly/witchcraft/utils/SympathyHelper.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 public class SympathyHelper {
     public static boolean isBound(ItemStack item) {
         CompoundTag tag = item.getTag();
-        return tag != null && tag.contains("target");
+        return tag != null && tag.hasUUID("target") && tag.contains("type");
     }
 
     public static boolean isBoss(Entity entity) {


### PR DESCRIPTION
## Summary
- Added robust NBT validation in BloodyNeedle crafting event handler
- Enhanced SympathyHelper.isBound() to validate both UUID and type data exist  
- Crafting now fails gracefully with error logging instead of crashing

## Background
Fixes crash when crafting bound poppets with bloody needles that lack proper NBT data (such as those obtained via `/give` commands). The original code assumed NBT data would always be properly formatted.

## Changes
- Added validation checks for both UUID and type data before attempting to read them
- Improved `SympathyHelper.isBound()` to be more robust
- Enhanced error logging to help diagnose malformed needles

## Test plan
- [x] Compile test passes
- [ ] Test with `/give` command bloody needle
- [ ] Verify proper error logging
- [ ] Confirm normal crafting still works

Closes #117

🤖 Generated with [Claude Code](https://claude.ai/code)