### PR TITLE
feat: generate tier requirements when carrying scented flowers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- tier requirements now generate when players carry scented M&A flowers, making progression accessible through witch gossip alone
+
 ### Changed
 - improved "Ritual: Sympathy" guidebook entry to explain how to obtain bloody needles for bound poppet creation
 

--- a/src/main/java/org/sosly/witchcraft/events/items/ScentDetection.java
+++ b/src/main/java/org/sosly/witchcraft/events/items/ScentDetection.java
@@ -1,6 +1,8 @@
 package org.sosly.witchcraft.events.items;
 
 import com.mojang.logging.LogUtils;
+import com.mna.api.capabilities.IPlayerProgression;
+import com.mna.capabilities.playerdata.progression.PlayerProgressionProvider;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.event.TickEvent;
@@ -8,8 +10,11 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import org.slf4j.Logger;
 import org.sosly.witchcraft.Witchcraft;
+import org.sosly.witchcraft.api.capabilities.ICovenCapability;
+import org.sosly.witchcraft.capabilities.coven.CovenProvider;
 import org.sosly.witchcraft.effects.EffectRegistry;
 import org.sosly.witchcraft.utils.ScentedItemHelper;
+import org.sosly.witchcraft.utils.TierEffectManager;
 
 @Mod.EventBusSubscriber(modid = Witchcraft.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class ScentDetection {
@@ -42,5 +47,39 @@ public class ScentDetection {
         }
         
         player.addEffect(new MobEffectInstance(EffectRegistry.NICE_SMELL.get(), 100, 0, false, false));
+        
+        generateRequirementsIfNeeded(player);
+    }
+    
+    private static void generateRequirementsIfNeeded(Player player) {
+        if (player.level().isClientSide()) {
+            return;
+        }
+        
+        IPlayerProgression progression = player.getCapability(PlayerProgressionProvider.PROGRESSION)
+                .orElse(null);
+        if (progression == null) {
+            LOGGER.warn("Player {} missing progression capability when generating tier requirements", 
+                player.getName().getString());
+            return;
+        }
+        
+        int nextTier = progression.getTier() + 1;
+        if (nextTier < 3 || nextTier > 5) {
+            return;
+        }
+        
+        ICovenCapability covenCap = player.getCapability(CovenProvider.COVEN)
+                .orElse(null);
+        if (covenCap == null) {
+            LOGGER.error("Player {} missing coven capability when generating tier requirements", 
+                player.getName().getString());
+            return;
+        }
+        
+        if (covenCap.getTierEffectsRequired(nextTier) == null) {
+            var requirements = TierEffectManager.generateTierRequirements(nextTier, player.getRandom(), player.level());
+            covenCap.setTierEffectsRequired(nextTier, requirements);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Added tier requirement generation to ScentDetection player tick event
- Players now get progression requirements when carrying M&A flowers
- Makes witch gossip progression system completely self-contained

## Background
Fixes the core issue in #114 where players following the natural witch gossip progression path (carrying flowers → nice smell effect → witch gossip) would get stuck because tier requirements were only generated through sympathy magic crafting.

## Changes
- Enhanced `ScentDetection.java` to generate tier requirements when players carry scented items
- Added necessary imports and logic for progression capability handling
- Existing poppet/needle triggers remain as additional pathways

## Test plan
- [x] Compile test passes
- [ ] Test that carrying M&A flowers generates requirements for tiers 3-5
- [ ] Verify witch gossip works after flower-triggered generation
- [ ] Confirm existing sympathy magic triggers still work

Closes #114

🤖 Generated with [Claude Code](https://claude.ai/code)