### PR TITLE
Fix Mage Robe Armor regen bonus affecting Coven players

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed crash when crafting bound poppet with bloody needle lacking proper NBT data (such as from /give command)
 - fixed "Swept Away" advancement triggering on any inventory change instead of only when obtaining flying broom
 - fixed "Swept Away" advancement appearing in its own category instead of under M&A tier progression
+- fixed Mage Robe Armor regeneration bonus incorrectly affecting Coven players (witches cannot regenerate essence naturally)
 
 ## [1.20.1-forge-0.3.0-alpha](https://github.com/SoSly/MnAWitchcraft/releases/tag/1.20.1-forge-0.3.0-alpha)
 ### Added

--- a/src/main/java/org/sosly/witchcraft/factions/resources/Essence.java
+++ b/src/main/java/org/sosly/witchcraft/factions/resources/Essence.java
@@ -21,6 +21,22 @@ public class Essence extends SimpleCastingResource {
     }
 
     @Override
+    public void addRegenerationModifier(String identifier, float modifier) {
+        if ("mage_armor_set_bonus".equals(identifier)) {
+            return;
+        }
+        super.addRegenerationModifier(identifier, modifier);
+    }
+
+    @Override
+    public void removeRegenerationModifier(String identifier) {
+        if ("mage_armor_set_bonus".equals(identifier)) {
+            return;
+        }
+        super.removeRegenerationModifier(identifier);
+    }
+
+    @Override
     public float getRegenerationModifier(LivingEntity caster) {
         if (super.getRegenerationModifier(caster) == 1.0F) {
             return 0;


### PR DESCRIPTION
## Summary
- Fixed Mage Robe Armor regeneration bonus incorrectly affecting Coven players
- Witches (Coven faction) cannot regenerate essence naturally, but MNA's mage armor was bypassing this restriction
- Added targeted overrides to block only the mage armor set bonus while preserving other regen sources like potions

## Test plan
- [x] Verify Coven players wearing mage armor no longer regenerate essence naturally
- [x] Confirm regeneration potions still work for Coven players
- [x] Ensure mage armor still provides regen for non-Coven players

Resolves #115

🤖 Generated with [Claude Code](https://claude.ai/code)