### PR TITLE
Release 0.3.1-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.20.1-forge-0.3.1-alpha]
 ### Added
 - tier requirements now generate when players carry scented M&A flowers, making progression accessible through witch gossip alone
 - added "Sworn to the Hedge" advancement for joining the Coven faction

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.daemon=false
 ####################
 ## Mod Information
 ####################
-mod_version = 0.3.0-alpha
+mod_version = 0.3.1-alpha
 mod_authors = nivthefox
 mod_group = org.sosly.witchcraft
 mod_id = mnaw


### PR DESCRIPTION
## Summary
- Prepare release 0.3.1-alpha
- Updated version in gradle.properties to 0.3.1-alpha  
- Finalized changelog with all changes for this release

## Changes in this release
- tier requirements now generate when players carry scented M&A flowers, making progression accessible through witch gossip alone
- added "Sworn to the Hedge" advancement for joining the Coven faction
- improved "Ritual: Sympathy" guidebook entry to explain how to obtain bloody needles for bound poppet creation
- fixed crash when crafting bound poppet with bloody needle lacking proper NBT data (such as from /give command)
- fixed "Swept Away" advancement triggering on any inventory change instead of only when obtaining flying broom
- fixed "Swept Away" advancement appearing in its own category instead of under M&A tier progression
- fixed Mage Robe Armor regeneration bonus incorrectly affecting Coven players (witches cannot regenerate essence naturally)

## Test plan
- [x] Version updated in gradle.properties
- [x] Changelog finalized for release

🤖 Generated with [Claude Code](https://claude.ai/code)