### PR TITLE
Fix faction spell filter for coven advancement requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- fixed faction-locked spells appearing as coven advancement requirements, making progression impossible without extensive trading
+
 ## [1.20.1-forge-0.3.1-alpha]
 ### Added
 - tier requirements now generate when players carry scented M&A flowers, making progression accessible through witch gossip alone

--- a/src/main/java/org/sosly/witchcraft/events/Factions.java
+++ b/src/main/java/org/sosly/witchcraft/events/Factions.java
@@ -98,7 +98,7 @@ public class Factions {
         }
         
         if (covenCap.getTierEffectsRequired(nextTier) == null) {
-            var requirements = TierEffectManager.generateTierRequirements(nextTier, player.getRandom(), player.level());
+            var requirements = TierEffectManager.generateTierRequirements(nextTier, player.getRandom(), player);
             covenCap.setTierEffectsRequired(nextTier, requirements);
             LOGGER.info("Generated tier {} requirements for player {}: {}", 
                 nextTier, player.getName().getString(), requirements);

--- a/src/main/java/org/sosly/witchcraft/events/items/ScentDetection.java
+++ b/src/main/java/org/sosly/witchcraft/events/items/ScentDetection.java
@@ -78,7 +78,7 @@ public class ScentDetection {
         }
         
         if (covenCap.getTierEffectsRequired(nextTier) == null) {
-            var requirements = TierEffectManager.generateTierRequirements(nextTier, player.getRandom(), player.level());
+            var requirements = TierEffectManager.generateTierRequirements(nextTier, player.getRandom(), player);
             covenCap.setTierEffectsRequired(nextTier, requirements);
         }
     }

--- a/src/main/java/org/sosly/witchcraft/rituals/effects/HedgeRitual.java
+++ b/src/main/java/org/sosly/witchcraft/rituals/effects/HedgeRitual.java
@@ -139,7 +139,7 @@ public class HedgeRitual extends RitualEffect {
         }
         
         var requirements = TierEffectManager.generateTierRequirements(nextTier + 1, 
-            caster.getRandom(), level);
+            caster.getRandom(), caster);
         covenCap.setTierEffectsRequired(nextTier + 1, requirements);
 
         caster.sendSystemMessage(Component.translatable("ritual.mnaw.hedge.success"));

--- a/src/main/java/org/sosly/witchcraft/utils/TierEffectManager.java
+++ b/src/main/java/org/sosly/witchcraft/utils/TierEffectManager.java
@@ -1,14 +1,19 @@
 package org.sosly.witchcraft.utils;
 
 import com.mna.Registries;
+import com.mna.api.capabilities.IPlayerProgression;
+import com.mna.api.faction.IFaction;
 import com.mna.api.spells.parts.SpellEffect;
+import com.mna.capabilities.playerdata.progression.PlayerProgressionProvider;
 import com.mna.spells.components.PotionEffectComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.registries.IForgeRegistry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.sosly.witchcraft.factions.FactionRegistry;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -20,54 +25,58 @@ import java.util.stream.Collectors;
  */
 public class TierEffectManager {
     private static final Logger LOGGER = LogManager.getLogger(TierEffectManager.class);
-    
+
     private static final int TIER_3_REQUIREMENTS = 3;
     private static final int TIER_4_REQUIREMENTS = 4;
     private static final int TIER_5_REQUIREMENTS = 5;
-    
+
     /**
      * Generates random spell effect requirements for a specific tier
      * @param tier the tier to generate requirements for (3-5)
      * @param rand the random source
-     * @param level the level to check tier requirements against
+     * @param player the player to generate requirements for (used for faction filtering)
      * @return a Set of ResourceLocations representing required spell effects
      */
-    public static Set<ResourceLocation> generateTierRequirements(int tier, RandomSource rand, Level level) {
-        List<ResourceLocation> availableEffects = getAllPotionEffects(tier, level);
-        
+    public static Set<ResourceLocation> generateTierRequirements(int tier, RandomSource rand, Player player) {
+        List<ResourceLocation> availableEffects = getAllPotionEffectComponents(tier, player);
+
         if (availableEffects.isEmpty()) {
             LOGGER.warn("No potion effects found for tier {}", tier);
             return new HashSet<>();
         }
-        
+
         int requiredCount = switch (tier) {
             case 3 -> TIER_3_REQUIREMENTS;
             case 4 -> TIER_4_REQUIREMENTS;
             case 5 -> TIER_5_REQUIREMENTS;
             default -> 0;
         };
-        
+
         Set<ResourceLocation> requirements = new HashSet<>();
         List<ResourceLocation> shuffled = new ArrayList<>(availableEffects);
         Collections.shuffle(shuffled, new Random(rand.nextLong()));
-        
+
         for (int i = 0; i < Math.min(requiredCount, shuffled.size()); i++) {
             requirements.add(shuffled.get(i));
         }
-        
+
         LOGGER.info("Generated {} requirements for tier {}: {}", requirements.size(), tier, requirements);
         return requirements;
     }
-    
+
     /**
-     * Gets all potion effects available for a specific tier
-     * @param tier the tier to get effects for
-     * @param level the level to check tier requirements against
-     * @return a List of ResourceLocations for available potion effects
+     * Gets all potion effect components available for a specific tier and player faction
+     * @param tier the tier to get components for
+     * @param player the player to check faction requirements against
+     * @return a List of ResourceLocations for available potion effect components
      */
-    private static List<ResourceLocation> getAllPotionEffects(int tier, Level level) {
-        IForgeRegistry<SpellEffect> registry = (IForgeRegistry<SpellEffect>) Registries.SpellEffect.get();
-        
+    private static List<ResourceLocation> getAllPotionEffectComponents(int tier, Player player) {
+        IForgeRegistry<SpellEffect> registry = Registries.SpellEffect.get();
+
+        IPlayerProgression progression = player.getCapability(PlayerProgressionProvider.PROGRESSION)
+                .orElse(null);
+        IFaction playerFaction = progression != null ? progression.getAlliedFaction() : null;
+
         return registry.getEntries().stream()
                 .filter(entry -> {
                     SpellEffect effect = entry.getValue();
@@ -75,7 +84,21 @@ public class TierEffectManager {
                         return false;
                     }
 
-                    return effect.getTier(level) == (tier - 1);
+                    if (effect.getTier(player.level()) != (tier - 1)) {
+                        return false;
+                    }
+
+                    IFaction requiredFaction = effect.getFactionRequirement();
+                    if (requiredFaction != null) {
+                        if (playerFaction == null) {
+                            return false;
+                        }
+                        if (playerFaction != requiredFaction) {
+                            return false;
+                        }
+                    }
+
+                    return true;
                 })
                 .map(entry -> entry.getKey().location())
                 .collect(Collectors.toList());


### PR DESCRIPTION
## Summary
- Filters faction-locked spells from coven tier advancement requirements
- Prevents impossible progression scenarios where players get spells they can't cast
- Renames method for clarity and adds proper faction checking

## Changes
- Added faction filtering logic to `TierEffectManager.getAllPotionEffectComponents()`
- Updated method signatures to accept `Player` instead of just `Level` 
- Renamed `getAllPotionEffects()` to `getAllPotionEffectComponents()` for clarity
- Updated all call sites in `ScentDetection`, `Factions`, and `HedgeRitual`
- Added proper javadoc and early return patterns

## Test plan
- [ ] Create tier 3/4 coven witch character
- [ ] Carry MnA flowers near witch to generate requirements
- [ ] Verify only non-faction or coven-faction spells appear in requirements list
- [ ] Test with both COVEN and DARK_COVEN factions to ensure compatibility
- [ ] Verify normal advancement flow still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)