### PR TITLE
Fix spell requirements death persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- fixed spell requirements and completion progress resetting on player death/respawn
 - fixed faction-locked spells appearing as coven advancement requirements, making progression impossible without extensive trading
 
 ## [1.20.1-forge-0.3.1-alpha]

--- a/src/main/java/org/sosly/witchcraft/api/capabilities/IBroomCapability.java
+++ b/src/main/java/org/sosly/witchcraft/api/capabilities/IBroomCapability.java
@@ -32,4 +32,10 @@ public interface IBroomCapability {
     void setLastKnownDimension(@Nullable ResourceLocation dimension);
 
     void reset();
+
+    /**
+     * Copies all data from another broom capability (used for death persistence)
+     * @param other the capability to copy from
+     */
+    void copyFrom(IBroomCapability other);
 }

--- a/src/main/java/org/sosly/witchcraft/api/capabilities/ICovenCapability.java
+++ b/src/main/java/org/sosly/witchcraft/api/capabilities/ICovenCapability.java
@@ -69,4 +69,10 @@ public interface ICovenCapability {
      */
     Map<ResourceLocation, Boolean> getTierEffectsProgress(int tier);
 
+    /**
+     * Copies all data from another coven capability (used for death persistence)
+     * @param other the capability to copy from
+     */
+    void copyFrom(ICovenCapability other);
+
 }

--- a/src/main/java/org/sosly/witchcraft/capabilities/broom/BroomCapability.java
+++ b/src/main/java/org/sosly/witchcraft/capabilities/broom/BroomCapability.java
@@ -67,4 +67,12 @@ public class BroomCapability implements IBroomCapability {
         this.lastKnownPosition = null;
         this.lastKnownDimension = null;
     }
+
+    @Override
+    public void copyFrom(IBroomCapability other) {
+        this.bondedBroomId = other.getBondedBroomId();
+        this.broomsUnlocked = other.broomsUnlocked();
+        this.lastKnownPosition = other.getLastKnownPosition();
+        this.lastKnownDimension = other.getLastKnownDimension();
+    }
 }

--- a/src/main/java/org/sosly/witchcraft/capabilities/coven/CovenCapability.java
+++ b/src/main/java/org/sosly/witchcraft/capabilities/coven/CovenCapability.java
@@ -91,4 +91,17 @@ public class CovenCapability implements ICovenCapability {
     public Map<ResourceLocation, Boolean> getTierEffectsProgress(int tier) {
         return tierEffectsProgress.get(tier);
     }
+
+    @Override
+    public void copyFrom(ICovenCapability other) {
+        malice = other.hasMalice();
+        
+        tierEffectsProgress.clear();
+        for (int tier = 3; tier <= 5; tier++) {
+            Map<ResourceLocation, Boolean> otherProgress = other.getTierEffectsProgress(tier);
+            if (otherProgress != null) {
+                tierEffectsProgress.put(tier, new HashMap<>(otherProgress));
+            }
+        }
+    }
 }

--- a/src/main/java/org/sosly/witchcraft/events/Factions.java
+++ b/src/main/java/org/sosly/witchcraft/events/Factions.java
@@ -37,6 +37,31 @@ public class Factions {
     }
     
     /**
+     * Handles player death to preserve capability data across respawn
+     */
+    @SubscribeEvent
+    public static void onPlayerClone(PlayerEvent.Clone event) {
+        Player player = event.getEntity();
+        Player original = event.getOriginal();
+        
+        original.reviveCaps();
+        
+        player.getCapability(CovenProvider.COVEN).ifPresent(coven -> {
+            original.getCapability(CovenProvider.COVEN).ifPresent(oldCoven -> {
+                coven.copyFrom(oldCoven);
+            });
+        });
+        
+        player.getCapability(BroomProvider.BROOM).ifPresent(broom -> {
+            original.getCapability(BroomProvider.BROOM).ifPresent(oldBroom -> {
+                broom.copyFrom(oldBroom);
+            });
+        });
+        
+        original.invalidateCaps();
+    }
+    
+    /**
      * Detects when a player crafts a bound poppet
      */
     @SubscribeEvent


### PR DESCRIPTION
## Summary
- Fixes spell requirements and completion progress resetting on player death/respawn
- Preserves broom bonding data through death
- Follows MnA's capability persistence pattern using PlayerEvent.Clone

## Changes
- Added `copyFrom()` methods to `CovenCapability` and `BroomCapability`
- Added `PlayerEvent.Clone` handler in `Factions.java` to copy capability data on death
- Uses proper `reviveCaps()` and `invalidateCaps()` sequence for safety
- Deep copies all tier progress maps to avoid reference issues

## Test plan
- [ ] Generate spell requirements by carrying MnA flowers near witch
- [ ] Note specific requirements and mark some as completed
- [ ] Die and respawn (both bed respawn and world spawn)
- [ ] Verify requirements and completion progress persist exactly
- [ ] Test with bonded broom to ensure bond survives death
- [ ] Verify no issues with dimension travel

🤖 Generated with [Claude Code](https://claude.ai/code)