### PR TITLE
fix: Witch's Cauldron refill after bucket emptying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - fixed spell requirements and completion progress resetting on player death/respawn
 - fixed faction-locked spells appearing as coven advancement requirements, making progression impossible without extensive trading
+- fixed Witch's Cauldron not refilling with moonlight after being emptied with bucket (only affected bucket interaction, not bottles)
 
 ## [1.20.1-forge-0.3.1-alpha]
 ### Added

--- a/src/main/java/org/sosly/witchcraft/blocks/alchemy/WitchsCauldronBlockEntity.java
+++ b/src/main/java/org/sosly/witchcraft/blocks/alchemy/WitchsCauldronBlockEntity.java
@@ -189,6 +189,8 @@ public class WitchsCauldronBlockEntity extends BlockEntity {
         
         if (wasEmpty && !isEmpty()) {
             switchToFilledCauldron();
+        } else if (!wasEmpty && isEmpty()) {
+            switchToEmptyCauldron();
         } else if (!wasEmpty && !isEmpty()) {
             updateBlockStateLevel();
         }


### PR DESCRIPTION
## Summary
- Fixed bucket emptying not properly transitioning cauldron to empty state
- Bucket emptying now refills with moonlight like bottle emptying
- Added missing state transition logic in WitchsCauldronBlockEntity.setFluid()

## Test plan
- [x] Place Witch's Cauldron under open sky, wait for moonlight fill
- [x] Empty with bottle, verify refills over time  
- [x] Empty with bucket, verify refills over time (previously failed)
- [x] Verify no regression in bottle interaction behavior
- [x] Build passes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)