### PR TITLE
fix: Witch's Cauldron extinguished campfire heat detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed spell requirements and completion progress resetting on player death/respawn
 - fixed faction-locked spells appearing as coven advancement requirements, making progression impossible without extensive trading
 - fixed Witch's Cauldron not refilling with moonlight after being emptied with bucket (only affected bucket interaction, not bottles)
+- fixed Witch's Cauldron continuing to heat from extinguished campfires (now properly checks campfire lit state)
+
+### Added
+- added soul campfire support as heat source for Witch's Cauldron
 
 ## [1.20.1-forge-0.3.1-alpha]
 ### Added

--- a/src/main/java/org/sosly/witchcraft/blocks/alchemy/WitchsCauldronBlockEntity.java
+++ b/src/main/java/org/sosly/witchcraft/blocks/alchemy/WitchsCauldronBlockEntity.java
@@ -24,6 +24,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.CampfireBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.gameevent.GameEvent;
@@ -80,6 +81,7 @@ public class WitchsCauldronBlockEntity extends BlockEntity {
     private static final HashMap<Block, Float> HEATERS = new HashMap<>();
     static {
         HEATERS.put(Blocks.CAMPFIRE, 1.0f);
+        HEATERS.put(Blocks.SOUL_CAMPFIRE, 1.0f);
         HEATERS.put(Blocks.FIRE, 2.0f);
         HEATERS.put(Blocks.LAVA, 5.0f);
         HEATERS.put(Blocks.ICE, -2.0f);
@@ -312,13 +314,16 @@ public class WitchsCauldronBlockEntity extends BlockEntity {
     }
     
     private void tickHeatAndStir() {
-        Block below = level.getBlockState(worldPosition.below()).getBlock();
+        BlockState belowState = level.getBlockState(worldPosition.below());
+        Block below = belowState.getBlock();
         float preHeat = heat;
         
-        if (HEATERS.containsKey(below)) {
-            heat = Mth.clamp(heat + HEATERS.get(below), MIN_TEMP, MAX_TEMP);
-        } else {
+        if (!HEATERS.containsKey(below)) {
             heat = Mth.clamp(heat - (1 - myBiome.getBaseTemperature()) * 10, MIN_TEMP, MAX_TEMP);
+        } else if (isCampfire(below) && !belowState.getValue(CampfireBlock.LIT)) {
+            heat = Mth.clamp(heat - (1 - myBiome.getBaseTemperature()) * 10, MIN_TEMP, MAX_TEMP);
+        } else {
+            heat = Mth.clamp(heat + HEATERS.get(below), MIN_TEMP, MAX_TEMP);
         }
         
         if (stir > 0.25f) {
@@ -379,6 +384,10 @@ public class WitchsCauldronBlockEntity extends BlockEntity {
                     0, 0.01f + (0.25f - stir) * 0.25f, 0);
             }
         }
+    }
+    
+    private boolean isCampfire(Block block) {
+        return block == Blocks.CAMPFIRE || block == Blocks.SOUL_CAMPFIRE;
     }
     
     public float getHeat() {


### PR DESCRIPTION
# Fix extinguished campfire heat detection
Witch's Cauldrons now properly stop heating when campfires underneath are extinguished.

## Changes
- Modified heat detection to check campfire BlockState lit property
- Added soul campfire support as heat source
- Refactored tickHeatAndStir() logic for better readability with early returns

## Related Issues
Resolves #126

## Implementation Notes
The bug was in tickHeatAndStir() which only checked Block type, not BlockState. Extinguished campfires have lit=false but were still providing heat. Now checks isCampfire(block) && !state.getValue(CampfireBlock.LIT) to properly handle extinguished campfires.

## Breaking Changes
None