### PR TITLE
fix: add dedication recharge support to Witch's Cauldron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed faction-locked spells appearing as coven advancement requirements, making progression impossible without extensive trading
 - fixed Witch's Cauldron not refilling with moonlight after being emptied with bucket (only affected bucket interaction, not bottles)
 - fixed Witch's Cauldron continuing to heat from extinguished campfires (now properly checks campfire lit state)
+- fixed Witch's Cauldron not recharging dedication-enchanted items (now supports mana boost and mana regen brews like Mystic Crucible)
 
 ### Added
 - added soul campfire support as heat source for Witch's Cauldron

--- a/src/main/java/org/sosly/witchcraft/events/enchantments/Dedication.java
+++ b/src/main/java/org/sosly/witchcraft/events/enchantments/Dedication.java
@@ -17,10 +17,10 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import org.slf4j.Logger;
 import org.sosly.witchcraft.Witchcraft;
+import org.sosly.witchcraft.blocks.alchemy.WitchsCauldronBlockEntity;
 import org.sosly.witchcraft.compat.MysticAlchemyCompat;
 import org.sosly.witchcraft.enchantments.EnchantmentRegistry;
 import org.sosly.witchcraft.enchantments.staves.DedicationEnchantment;
-import org.sosly.witchcraft.compat.MysticAlchemyCompat;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -53,12 +53,19 @@ public class Dedication {
             return;
         }
 
-        var crucible = MysticAlchemyCompat.getCrucibleTile(level, pos);
-        if (crucible == null) {
+        if (tryRechargeCrucible(level, pos, stack)) {
             return;
         }
 
-        BlockState state = level.getBlockState(pos);
+        tryRechargeWitchsCauldron(level, pos, stack);
+    }
+
+    private static boolean tryRechargeCrucible(Level level, BlockPos pos, ItemStack stack) {
+        var crucible = MysticAlchemyCompat.getCrucibleTile(level, pos);
+        if (crucible == null) {
+            return false;
+        }
+
         AtomicBoolean success = new AtomicBoolean(false);
         MysticAlchemyCompat.getProminentEffects(crucible).forEach((effect, strength) -> {
             if (effect.equals(EffectInit.INSTANT_MANA.get()) || effect.equals(EffectInit.MANA_REGEN.get())) {
@@ -68,16 +75,40 @@ public class Dedication {
         });
 
         if (!success.get()) {
-            return;
+            return false;
         }
         
+        BlockState state = level.getBlockState(pos);
         int existingLevel = state.getValue(LayeredCauldronBlock.LEVEL);
         if (existingLevel == 1) {
             level.setBlock(pos, MysticAlchemyCompat.getEmptyCrucibleState(), 3);
+        } else {
+            level.setBlock(pos, state.setValue(LayeredCauldronBlock.LEVEL, existingLevel - 1), 3);
+        }
+        return true;
+    }
+
+    private static void tryRechargeWitchsCauldron(Level level, BlockPos pos, ItemStack stack) {
+        var blockEntity = level.getBlockEntity(pos);
+        if (!(blockEntity instanceof WitchsCauldronBlockEntity cauldron)) {
             return;
         }
-        
-        level.setBlock(pos, state.setValue(LayeredCauldronBlock.LEVEL, existingLevel - 1), 3);
+
+        if (cauldron.isEmpty() || !cauldron.isPotion()) {
+            return;
+        }
+
+        AtomicBoolean success = new AtomicBoolean(false);
+        cauldron.getProminentEffects().forEach((effect, strength) -> {
+            if (effect.equals(EffectInit.INSTANT_MANA.get()) || effect.equals(EffectInit.MANA_REGEN.get())) {
+                DedicationEnchantment.addMana(stack, (int) (strength * 1.0F));
+                success.set(true);
+            }
+        });
+
+        if (success.get()) {
+            cauldron.drain();
+        }
     }
 
     @SubscribeEvent


### PR DESCRIPTION
# Add dedication recharge support to Witch's Cauldron
Witch's Cauldrons can now recharge dedication-enchanted staves, providing feature parity with Mystic Crucibles.

## Changes
- Extended Dedication event handler to support Witch's Cauldron BlockEntity
- Added mana boost and mana regen brew detection for cauldrons
- Refactored logic into clean helper methods for better maintainability
- Works with both water and moonlight-based brews (moonlight is a bonus feature)

## Related Issues
Resolves #127

## Implementation Notes
Maintains existing crucible behavior while adding parallel support for cauldrons. Uses the same strength calculation and recharge logic. Cauldron drains one level per recharge using existing drain() method.

## Breaking Changes
None