### PR TITLE
Release 0.3.2-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.20.1-forge-0.3.2-alpha](https://github.com/SoSly/MNAWitchcraft/releases/tag/1.20.1-forge-0.3.2-alpha)
 ### Fixed
 - fixed spell requirements and completion progress resetting on player death/respawn
 - fixed faction-locked spells appearing as coven advancement requirements, making progression impossible without extensive trading

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.daemon=false
 ####################
 ## Mod Information
 ####################
-mod_version = 0.3.1-alpha
+mod_version = 0.3.2-alpha
 mod_authors = nivthefox
 mod_group = org.sosly.witchcraft
 mod_id = mnaw


### PR DESCRIPTION
# Release 0.3.2-alpha
Prepare 0.3.2-alpha release with bug fixes and improvements to Witch's Cauldron functionality.

## Changes
- Bumped version to 0.3.2-alpha in gradle.properties
- Updated changelog with release notes and GitHub release link
- Moved unreleased changes to 0.3.2-alpha section

## Release Notes
This release focuses on fixing several Witch's Cauldron bugs and adding missing features:

### Fixed
- Spell requirements and completion progress resetting on player death/respawn
- Faction-locked spells appearing as coven advancement requirements
- Witch's Cauldron not refilling with moonlight after bucket emptying
- Witch's Cauldron continuing to heat from extinguished campfires
- Witch's Cauldron not recharging dedication-enchanted items

### Added
- Soul campfire support as heat source for Witch's Cauldron

## Breaking Changes
None