### PR TITLE
fix: correct player charm binding check in Ritual of Sympathy

### DIFF
--- a/src/main/java/org/sosly/witchcraft/rituals/effects/SympathyRitual.java
+++ b/src/main/java/org/sosly/witchcraft/rituals/effects/SympathyRitual.java
@@ -102,7 +102,7 @@ public class SympathyRitual extends RitualEffect {
         }
 
         ItemStack charmItem = getPlayerCharm(ctx);
-        if (charmItem.isEmpty() || ((PlayerCharm)charmItem.getItem()).getPlayerUUID(charmItem) != player.getUUID()) {
+        if (charmItem.isEmpty() || !player.getUUID().equals(((PlayerCharm)charmItem.getItem()).getPlayerUUID(charmItem))) {
             player.sendSystemMessage(Component.translatable("rituals.sympathy.not_your_charm"));
             return false;
         }


### PR DESCRIPTION
# Fix Player Charm Binding Check
Corrects the UUID comparison logic for player charm binding verification in the Ritual of Sympathy. The ritual was incorrectly using reference equality instead of value equality, causing bound charms to always be reported as unbound.

## Changes
- Changed UUID comparison from `!=` operator to `.equals()` method in SympathyRitual.java:105
- Comparison now properly verifies UUID values rather than object references

## Related Issues
Closes #136

## Implementation Notes
Used `.equals()` on the player UUID to handle null checks safely while comparing values. The M&A PlayerCharm API is working correctly - our lookup logic was just using wrong comparison operator.

## Breaking Changes
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)