### PR TITLE
fix: add particle textures to poppet block models

### DIFF
--- a/src/main/resources/assets/mnaw/models/block/bound_poppet.json
+++ b/src/main/resources/assets/mnaw/models/block/bound_poppet.json
@@ -1,6 +1,9 @@
 {
   "parent": "forge:item/default",
   "loader": "forge:composite",
+  "textures": {
+    "particle": "minecraft:block/red_wool"
+  },
   "children": {
     "poppet": {
       "loader": "forge:obj",

--- a/src/main/resources/assets/mnaw/models/block/poppet.json
+++ b/src/main/resources/assets/mnaw/models/block/poppet.json
@@ -1,6 +1,9 @@
 {
   "parent": "forge:item/default",
   "loader": "forge:composite",
+  "textures": {
+    "particle": "minecraft:block/white_wool"
+  },
   "children": {
     "poppet": {
       "loader": "forge:obj",


### PR DESCRIPTION
# Add particle textures to poppet block models
Poppet blocks were showing textureless particles when broken. This fix adds particle texture definitions to both block models.

## Changes
- Added particle texture to poppet block model (white wool)
- Added particle texture to bound_poppet block model (red wool)

## Related Issues
Closes #46

## Implementation Notes
Block models using OBJ loaders need explicit particle texture definitions for break particles. The textures reference vanilla Minecraft wool blocks to match the poppet appearance.

## Breaking Changes
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)