### PR TITLE
chore: prepare release 0.3.3-preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.1-forge-0.3.3-preview](https://github.com/SoSly/MNAWitchcraft/releases/tag/1.20.1-forge-0.3.3-preview)
+### Fixed
+- fixed poppets showing textureless particles when broken
+- fixed player charm incorrectly reporting as unbound in Ritual of Sympathy
+- fixed spell demonstration advancements not progressing when casting spells directly
+
 ## [1.20.1-forge-0.3.2-alpha](https://github.com/SoSly/MNAWitchcraft/releases/tag/1.20.1-forge-0.3.2-alpha)
 ### Fixed
 - fixed spell requirements and completion progress resetting on player death/respawn

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.daemon=false
 ####################
 ## Mod Information
 ####################
-mod_version = 0.3.2-alpha
+mod_version = 0.3.3-preview
 mod_authors = nivthefox
 mod_group = org.sosly.witchcraft
 mod_id = mnaw


### PR DESCRIPTION
# Prepare release 0.3.3-preview
Updates version number and changelog for the 0.3.3-preview release.

## Changes
- Updated mod_version to 0.3.3-preview in gradle.properties
- Updated CHANGELOG.md with 0.3.3-preview release notes

## Related Issues
Part of milestone 0.3.3

## Implementation Notes
This release contains three bug fixes from milestone 0.3.3.

## Breaking Changes
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)